### PR TITLE
Remove hashMapFrom because it’s not a good API for dart

### DIFF
--- a/lib/src/collections.dart
+++ b/lib/src/collections.dart
@@ -60,17 +60,6 @@ KMutableMap<K, V> hashMapOf<K, V>([Map<K, V> map = const {}]) =>
     DartMutableMap.noCopy(HashMap.of(map));
 
 /**
- * Returns an empty new [HashMap].
- */
-KMutableMap<K, V> hashMapFrom<K, V>(KIterable<KPair<K, V>> pairs) {
-  var map = DartMutableMap.noCopy(HashMap<K, V>());
-  if (pairs != null) {
-    map.putAllPairs(pairs);
-  }
-  return map;
-}
-
-/**
  * Returns a new [LinkedHashMap] with the specified contents, given as a list of pairs
  * where the first component is the key and the second is the value.
  *

--- a/test/collections_test.dart
+++ b/test/collections_test.dart
@@ -86,15 +86,45 @@ void main() {
     });
   });
 
+  group("hashMapOf", () {
+    test("empty is mutable", () {
+      final map = hashMapOf<int, String>();
+      map[1] = "a";
+      expect(map.size, 1);
+      expect(map, mapOf({1: "a"}));
+    });
+
+    test("with empty map is mutable", () {
+      final map = hashMapOf<int, String>({});
+      map[1] = "a";
+      expect(map.size, 1);
+      expect(map, mapOf({1: "a"}));
+    });
+
+    test("mutation of original list doesn't manipulate original map", () {
+      var initialMap = {
+        1: "Bulbasaur",
+        2: "Ivysaur",
+      };
+      final map = hashMapOf<int, String>(initialMap);
+      map[1] = "a";
+      expect(map.size, 2);
+      expect(map, mapOf({1: "a", 2: "Ivysaur"}));
+
+      // original is unchanged
+      expect(initialMap[1], "Bulbasaur");
+    });
+  });
+
   group('hashSetOf', () {
     test("empty is mutable", () {
-      final set = hashSetOf<String>([]);
+      final set = hashSetOf<String>();
       set.add("test");
       expect(set.size, equals(1));
       expect(set, setOf(["test"]));
     });
 
-    test("empty is mutable", () {
+    test("with empty list is mutable", () {
       final set = hashSetOf<String>([]);
       set.add("test");
       expect(set.size, equals(1));


### PR DESCRIPTION
unlike kotlin, dart doesn’t support varargs and has no infix notation to create pairs. Using `hashMapOf` is much more preferable in any way over `hashMapFrom`

```dart
// dart, ok
hashMapOf({
  1: "a",
  2: "b",
});

// dart, urgh
hashMapFrom(listOf([
  KPair(1, "a"),
  KPair(2, "b"),
]));
```

```kotlin
// kotlin, ok
hashMapOf(
  1 to "a",
  2 to "b"
)
```