### PR TITLE
Require a valid index when setting value

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -42,7 +42,7 @@ linter:
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
-    # TODO - only_throw_errors
+    - only_throw_errors
     - overridden_fields
     # TODO    - package_api_docs # not a requirement but a best practice
     - package_names

--- a/lib/src/collection/impl/iterator.dart
+++ b/lib/src/collection/impl/iterator.dart
@@ -90,7 +90,8 @@ class InterOpKtListIterator<T>
   @override
   void set(T element) {
     if (lastRet < 0)
-      throw "illegal cursor state -1. next() or previous() not called";
+      throw IndexOutOfBoundsException(
+          "illegal cursor state -1. next() or previous() not called");
     list.replaceRange(lastRet, lastRet + 1, [element]);
   }
 }

--- a/test/collection/iterator_test.dart
+++ b/test/collection/iterator_test.dart
@@ -75,5 +75,10 @@ void main() {
       expect(i.next(), equals("b"));
       expect(i.previous(), equals("b"));
     });
+    test("set requires next() before beeing called", () {
+      final i = InterOpKtListIterator(["a", "b"], 0);
+      final e = catchException<IndexOutOfBoundsException>(() => i.set("x"));
+      expect(e.message, allOf(contains("-1"), contains("next()")));
+    });
   });
 }


### PR DESCRIPTION
- `KtMutableIterator.set` throw `IndexOutOfBoundsException` when `next()` wasn't called 