### PR TITLE
KtMap.map -> Iterable

### DIFF
--- a/lib/src/collection/extension/map_extensions_mixin.dart
+++ b/lib/src/collection/extension/map_extensions_mixin.dart
@@ -12,7 +12,7 @@ abstract class KtMapExtensionsMixin<K, V>
     if (isEmpty()) {
       return true;
     }
-    for (KtMapEntry<K, V> entry in entries.iter) {
+    for (KtMapEntry<K, V> entry in iter) {
       if (!predicate(entry.key, entry.value)) {
         return false;
       }
@@ -29,7 +29,7 @@ abstract class KtMapExtensionsMixin<K, V>
     if (isEmpty()) {
       return false;
     }
-    for (KtMapEntry<K, V> entry in entries.iter) {
+    for (KtMapEntry<K, V> entry in iter) {
       if (predicate(entry.key, entry.value)) {
         return true;
       }
@@ -51,7 +51,7 @@ abstract class KtMapExtensionsMixin<K, V>
       return true;
     }());
     final result = linkedMapFrom<K, V>();
-    for (final entry in entries.iter) {
+    for (final entry in iter) {
       if (predicate(entry.key)) {
         result.put(entry.key, entry.value);
       }
@@ -66,7 +66,7 @@ abstract class KtMapExtensionsMixin<K, V>
       return true;
     }());
     final result = linkedMapFrom<K, V>();
-    for (final entry in entries.iter) {
+    for (final entry in iter) {
       if (predicate(entry.value)) {
         result.put(entry.key, entry.value);
       }
@@ -88,7 +88,7 @@ abstract class KtMapExtensionsMixin<K, V>
             "\n\n$kBug35518GenericTypeError");
       return true;
     }());
-    for (final element in entries.iter) {
+    for (final element in iter) {
       if (predicate(element)) {
         destination.put(element.key, element.value);
       }
@@ -117,7 +117,7 @@ abstract class KtMapExtensionsMixin<K, V>
             "\n\n$kBug35518GenericTypeError");
       return true;
     }());
-    for (final element in entries.iter) {
+    for (final element in iter) {
       if (!predicate(element)) {
         destination.put(element.key, element.value);
       }
@@ -151,6 +151,12 @@ abstract class KtMapExtensionsMixin<K, V>
   bool isNotEmpty() => !isEmpty();
 
   @override
+  KtList<R> map<R>(R Function(KtMapEntry<K, V> entry) transform) {
+    final mapped = mapTo(mutableListOf<R>(), transform);
+    return mapped;
+  }
+
+  @override
   KtMap<R, V> mapKeys<R>(R Function(KtMapEntry<K, V>) transform) {
     final mapped = mapKeysTo(linkedMapFrom<R, V>(), transform);
     return mapped;
@@ -170,8 +176,28 @@ abstract class KtMapExtensionsMixin<K, V>
             "\n\n$kBug35518GenericTypeError");
       return true;
     }());
-    for (var element in entries.iter) {
+    for (final element in iter) {
       destination.put(transform(element), element.value);
+    }
+    return destination;
+  }
+
+  @override
+  M mapTo<R, M extends KtMutableCollection<dynamic>>(
+      M destination, R Function(KtMapEntry<K, V> entry) transform) {
+    assert(() {
+      if (destination == null) throw ArgumentError("destination can't be null");
+      if (transform == null) throw ArgumentError("transform can't be null");
+      if (destination is! KtMutableCollection<R> && mutableListFrom<R>() is! M)
+        throw ArgumentError("mapTo destination has wrong type parameters."
+            "\nExpected: KtMutableCollection<$R>, Actual: ${destination.runtimeType}"
+            "\nEntries after key transformation with $transform have type $R "
+            "and can't be copied into destination of type ${destination.runtimeType}."
+            "\n\n$kBug35518GenericTypeError");
+      return true;
+    }());
+    for (final item in iter) {
+      destination.add(transform(item));
     }
     return destination;
   }
@@ -196,7 +222,7 @@ abstract class KtMapExtensionsMixin<K, V>
             "\n\n$kBug35518GenericTypeError");
       return true;
     }());
-    for (var element in entries.iter) {
+    for (final element in iter) {
       destination.put(element.key, transform(element));
     }
     return destination;
@@ -251,7 +277,7 @@ abstract class KtMapExtensionsMixin<K, V>
     if (isEmpty()) {
       return true;
     }
-    for (KtMapEntry<K, V> entry in entries.iter) {
+    for (KtMapEntry<K, V> entry in iter) {
       if (predicate(entry.key, entry.value)) {
         return false;
       }

--- a/lib/src/collection/impl/map.dart
+++ b/lib/src/collection/impl/map.dart
@@ -13,7 +13,8 @@ class DartMap<K, V> with KtMapExtensionsMixin<K, V> implements KtMap<K, V> {
   int _hashCode;
 
   @override
-  Iterable<MapEntry<K, V>> get iter => _map.entries;
+  Iterable<KtMapEntry<K, V>> get iter =>
+      _map.entries.map((entry) => _Entry.from(entry));
 
   @override
   Map<K, V> asMap() => _map;

--- a/lib/src/collection/impl/map_empty.dart
+++ b/lib/src/collection/impl/map_empty.dart
@@ -3,7 +3,7 @@ import 'package:kt_dart/src/collection/extension/map_extensions_mixin.dart';
 
 class EmptyMap<K, V> with KtMapExtensionsMixin<K, V> implements KtMap<K, V> {
   @override
-  Iterable<MapEntry<K, V>> get iter => List.unmodifiable([]);
+  Iterable<KtMapEntry<K, V>> get iter => List.unmodifiable([]);
 
   @override
   Map<K, V> asMap() => Map.unmodifiable({});

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -22,7 +22,8 @@ class DartMutableMap<K, V>
   final Map<K, V> _map;
 
   @override
-  Iterable<MapEntry<K, V>> get iter => _map.entries;
+  Iterable<KtMapEntry<K, V>> get iter =>
+      _map.entries.map((entry) => _MutableEntry.from(entry));
 
   @override
   Map<K, V> asMap() => _map;

--- a/lib/src/collection/kt_map.dart
+++ b/lib/src/collection/kt_map.dart
@@ -28,7 +28,7 @@ abstract class KtMap<K, V> implements KtMapExtension<K, V> {
   /**
    * dart interop iterable for loops
    */
-  Iterable<MapEntry<K, V>> get iter;
+  Iterable<KtMapEntry<K, V>> get iter;
 
   /**
    * Returns a read-only dart:core [Map]
@@ -191,6 +191,12 @@ abstract class KtMapExtension<K, V> {
   bool isNotEmpty();
 
   /**
+   * Returns a list containing the results of applying the given [transform] function
+   * to each entry in the original map.
+   */
+  KtList<R> map<R>(R Function(KtMapEntry<K, V> entry) transform);
+
+  /**
    * Returns a new Map with entries having the keys obtained by applying the [transform] function to each entry in this
    * [Map] and the values of this map.
    *
@@ -214,6 +220,14 @@ abstract class KtMapExtension<K, V> {
    */
   // TODO Change to `M extends KtMutableMap<R, V>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
   M mapKeysTo<R, M extends KtMutableMap<dynamic, dynamic>>(
+      M destination, R Function(KtMapEntry<K, V> entry) transform);
+
+  /**
+   * Applies the given [transform] function to each entry of the original map
+   * and appends the results to the given [destination].
+   */
+  // TODO Change to `M extends KtMutableCollection<R>` once https://github.com/dart-lang/sdk/issues/35518 has been fixed
+  M mapTo<R, M extends KtMutableCollection<dynamic>>(
       M destination, R Function(KtMapEntry<K, V> entry) transform);
 
   /**


### PR DESCRIPTION
Mapping for maps.

Minor breaking change (typo fix) on top of #85 which makes `KtMap.iter` return `Iterable<KtMapEntry<K, V>>` instead of `Iterable<MapEntry<K, V>>`.

fixes #79 