### PR TITLE
Require non null collections for `from` constructors

### DIFF
--- a/lib/src/collection/kt_list.dart
+++ b/lib/src/collection/kt_list.dart
@@ -11,7 +11,11 @@ abstract class KtList<T> implements KtCollection<T>, KtListExtension<T> {
   factory KtList.empty() => EmptyList<T>();
 
   /// Returns a new read-only list based on [elements].
-  factory KtList.from([Iterable<T> elements = const []]) {
+  factory KtList.from([@nonNull Iterable<T> elements = const []]) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     if (elements.isEmpty) return EmptyList();
     return DartList(elements);
   }

--- a/lib/src/collection/kt_list_mutable.dart
+++ b/lib/src/collection/kt_list_mutable.dart
@@ -8,7 +8,11 @@ abstract class KtMutableList<T>
     implements KtList<T>, KtMutableCollection<T>, KtMutableListExtension<T> {
   factory KtMutableList.empty() => DartMutableList<T>();
 
-  factory KtMutableList.from([Iterable<T> elements = const []]) {
+  factory KtMutableList.from([@nonNull Iterable<T> elements = const []]) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     if (elements.isEmpty) return DartMutableList<T>();
     return DartMutableList(elements);
   }

--- a/lib/src/collection/kt_map.dart
+++ b/lib/src/collection/kt_map.dart
@@ -12,7 +12,11 @@ import 'package:kt_dart/src/collection/impl/map_empty.dart';
 abstract class KtMap<K, V> implements KtMapExtension<K, V> {
   factory KtMap.empty() => EmptyMap<K, V>();
 
-  factory KtMap.from([Map<K, V> map = const {}]) {
+  factory KtMap.from([@nonNull Map<K, V> map = const {}]) {
+    assert(() {
+      if (map == null) throw ArgumentError("map can't be null");
+      return true;
+    }());
     if (map.isEmpty) return EmptyMap<K, V>();
     return DartMap(map);
   }

--- a/lib/src/collection/kt_map_hash.dart
+++ b/lib/src/collection/kt_map_hash.dart
@@ -4,5 +4,11 @@ import 'package:kt_dart/src/collection/impl/map_hash.dart';
 abstract class KtHashMap<K, V> implements KtMutableMap<K, V> {
   factory KtHashMap.empty() => DartHashMap<K, V>();
 
-  factory KtHashMap.from([Map<K, V> map = const {}]) => DartHashMap(map);
+  factory KtHashMap.from([@nonNull Map<K, V> map = const {}]) {
+    assert(() {
+      if (map == null) throw ArgumentError("map can't be null");
+      return true;
+    }());
+    return DartHashMap(map);
+  }
 }

--- a/lib/src/collection/kt_map_linked.dart
+++ b/lib/src/collection/kt_map_linked.dart
@@ -4,6 +4,11 @@ import 'package:kt_dart/src/collection/impl/map_linked.dart';
 abstract class KtLinkedMap<K, V> implements KtMutableMap<K, V> {
   factory KtLinkedMap.empty() => DartLinkedHashMap<K, V>();
 
-  factory KtLinkedMap.from([Map<K, V> map = const {}]) =>
-      DartLinkedHashMap(map);
+  factory KtLinkedMap.from([@nonNull Map<K, V> map = const {}]) {
+    assert(() {
+      if (map == null) throw ArgumentError("map can't be null");
+      return true;
+    }());
+    return DartLinkedHashMap(map);
+  }
 }

--- a/lib/src/collection/kt_map_mutable.dart
+++ b/lib/src/collection/kt_map_mutable.dart
@@ -9,7 +9,13 @@ abstract class KtMutableMap<K, V>
     implements KtMap<K, V>, KtMutableMapExtension<K, V> {
   factory KtMutableMap.empty() => DartMutableMap<K, V>();
 
-  factory KtMutableMap.from([Map<K, V> map = const {}]) => DartMutableMap(map);
+  factory KtMutableMap.from([@nonNull Map<K, V> map = const {}]) {
+    assert(() {
+      if (map == null) throw ArgumentError("map can't be null");
+      return true;
+    }());
+    return DartMutableMap(map);
+  }
 
   /// Creates a [Map] instance that wraps the original [KtMap]. It acts as a view.
   ///

--- a/lib/src/collection/kt_set.dart
+++ b/lib/src/collection/kt_set.dart
@@ -12,7 +12,11 @@ abstract class KtSet<T> implements KtCollection<T> {
   factory KtSet.empty() => EmptySet<T>();
 
   /// Returns a new read-only set based on [elements].
-  factory KtSet.from([Iterable<T> elements = const []]) {
+  factory KtSet.from([@nonNull Iterable<T> elements = const []]) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     if (elements.isEmpty) return EmptySet<T>();
     return DartSet(elements);
   }

--- a/lib/src/collection/kt_set_hash.dart
+++ b/lib/src/collection/kt_set_hash.dart
@@ -5,7 +5,11 @@ import 'package:kt_dart/src/util/arguments.dart';
 abstract class KtHashSet<T> implements KtMutableSet<T> {
   factory KtHashSet.empty() => KtHashSet.from();
 
-  factory KtHashSet.from([Iterable<T> elements = const []]) {
+  factory KtHashSet.from([@nonNull Iterable<T> elements = const []]) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     return DartHashSet<T>(elements);
   }
 

--- a/lib/src/collection/kt_set_linked.dart
+++ b/lib/src/collection/kt_set_linked.dart
@@ -5,7 +5,11 @@ import 'package:kt_dart/src/util/arguments.dart';
 abstract class KtLinkedSet<T> implements KtMutableSet<T> {
   factory KtLinkedSet.empty() => KtLinkedSet.from();
 
-  factory KtLinkedSet.from([Iterable<T> elements = const []]) {
+  factory KtLinkedSet.from([@nonNull Iterable<T> elements = const []]) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     return DartLinkedSet<T>(elements);
   }
 

--- a/lib/src/collection/kt_set_mutable.dart
+++ b/lib/src/collection/kt_set_mutable.dart
@@ -8,7 +8,11 @@ import 'package:kt_dart/src/util/arguments.dart';
 abstract class KtMutableSet<T> implements KtSet<T>, KtMutableCollection<T> {
   factory KtMutableSet.empty() => KtMutableSet.from();
 
-  factory KtMutableSet.from([Iterable<T> elements = const []]) {
+  factory KtMutableSet.from([@nonNull Iterable<T> elements = const []]) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
     return DartMutableSet(elements);
   }
 

--- a/test/collection/list_test.dart
+++ b/test/collection/list_test.dart
@@ -342,6 +342,11 @@ void testList(
       expect(stringList.elementAtOrElse(0, (_) => "a"), null);
     });
 
+    test("listFrom requires non null iterable", () {
+      final e = catchException<ArgumentError>(() => listFrom(null));
+      expect(e.message, contains("elements can't be null"));
+    });
+
     if (mutable) {
       test("emptyList, asList allows mutation - empty", () {
         final ktList = emptyList<String>();

--- a/test/collection/map_test.dart
+++ b/test/collection/map_test.dart
@@ -1,6 +1,8 @@
 import 'package:kt_dart/collection.dart';
 import 'package:test/test.dart';
 
+import '../test/assert_dart.dart';
+
 void main() {
   group("mapFrom", () {
     testMap(<K, V>(Map<K, V> map) => mapFrom<K, V>(map));
@@ -156,4 +158,10 @@ void testMap(KtMap<K, V> Function<K, V>(Map<K, V> map) mapFrom,
       expect(keys, listOf(1, 2));
     });
   });
+
+  test("mapFrom requires non null map", () {
+    final e = catchException<ArgumentError>(() => mapFrom(null));
+    expect(e.message, contains("map can't be null"));
+  });
+
 }

--- a/test/collection/map_test.dart
+++ b/test/collection/map_test.dart
@@ -163,5 +163,4 @@ void testMap(KtMap<K, V> Function<K, V>(Map<K, V> map) mapFrom,
     final e = catchException<ArgumentError>(() => mapFrom(null));
     expect(e.message, contains("map can't be null"));
   });
-
 }

--- a/test/collection/set_test.dart
+++ b/test/collection/set_test.dart
@@ -223,6 +223,5 @@ void testSet(
       final e = catchException<ArgumentError>(() => setFrom(null));
       expect(e.message, contains("elements can't be null"));
     });
-
   });
 }

--- a/test/collection/set_test.dart
+++ b/test/collection/set_test.dart
@@ -218,5 +218,11 @@ void testSet(
         expect(e.message, contains("unmodifiable"));
       });
     }
+
+    test("setFrom requires non null iterable", () {
+      final e = catchException<ArgumentError>(() => setFrom(null));
+      expect(e.message, contains("elements can't be null"));
+    });
+
   });
 }


### PR DESCRIPTION
`listFrom(null)` throws an unclear error message. Now, it states correctly that the iterable argument has to be a non-null.  

fixes #94