### PR TITLE
Become fully Dart 2.0 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: dart
 sudo: false
 dart:
+  - 2.0.0
   - 2.1.0
+  - 2.2.0
 with_content_shell: false
 before_install:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - pub global run coverage:collect_coverage --port=8111 -o coverage.json --resume-isolates --wait-paused &
   - dart --observe=8111 --enable-asserts test/kt_dart_test.dart
   - pub global run coverage:format_coverage --packages=.packages --report-on lib --in coverage.json --out lcov.info --lcov
-  - pub publish -n
+  # pub is broken in version 2.2.0
+  - pub --version | grep -q '2.2.0' || pub publish -n
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/lib/src/collection/impl/dart_unmodifiable_set_view.dart
+++ b/lib/src/collection/impl/dart_unmodifiable_set_view.dart
@@ -7,7 +7,9 @@ import 'dart:collection';
 /// Methods that would change the set,
 /// such as [add] and [remove], throw an [UnsupportedError].
 /// Permitted operations defer to the wrapped set.
-class UnmodifiableSetView<E> extends Object with IterableMixin<E> implements Set<E>{
+class UnmodifiableSetView<E> extends Object
+    with IterableMixin<E>
+    implements Set<E> {
   UnmodifiableSetView(Set<E> set) : _set = set;
 
   final Set<E> _set;

--- a/lib/src/collection/impl/dart_unmodifiable_set_view.dart
+++ b/lib/src/collection/impl/dart_unmodifiable_set_view.dart
@@ -7,7 +7,7 @@ import 'dart:collection';
 /// Methods that would change the set,
 /// such as [add] and [remove], throw an [UnsupportedError].
 /// Permitted operations defer to the wrapped set.
-class UnmodifiableSetView<E> with IterableMixin<E> implements Set<E> {
+class UnmodifiableSetView<E> extends Object with IterableMixin<E> implements Set<E>{
   UnmodifiableSetView(Set<E> set) : _set = set;
 
   final Set<E> _set;

--- a/lib/src/collection/impl/list.dart
+++ b/lib/src/collection/impl/list.dart
@@ -6,7 +6,7 @@ import 'package:kt_dart/src/collection/impl/iterator.dart';
 import 'package:kt_dart/src/util/hash.dart';
 
 /// [KtList] implementation based on a dart [List]
-class DartList<T>
+class DartList<T> extends Object
     with
         KtIterableExtensionsMixin<T>,
         KtCollectionExtensionMixin<T>,

--- a/lib/src/collection/impl/list_empty.dart
+++ b/lib/src/collection/impl/list_empty.dart
@@ -4,7 +4,7 @@ import 'package:kt_dart/src/collection/extension/iterable_extension_mixin.dart';
 import 'package:kt_dart/src/collection/extension/list_extension_mixin.dart';
 import 'package:kt_dart/src/collection/impl/dart_iterable.dart';
 
-class EmptyList<T>
+class EmptyList<T> extends Object
     with
         KtIterableExtensionsMixin<T>,
         KtCollectionExtensionMixin<T>,

--- a/lib/src/collection/impl/list_mutable.dart
+++ b/lib/src/collection/impl/list_mutable.dart
@@ -9,7 +9,7 @@ import 'package:kt_dart/src/collection/impl/iterator.dart';
 import 'package:kt_dart/src/util/hash.dart';
 
 /// [KtList] based on a dart [List]
-class DartMutableList<T>
+class DartMutableList<T> extends Object
     with
         KtIterableExtensionsMixin<T>,
         KtCollectionExtensionMixin<T>,
@@ -159,8 +159,9 @@ class DartMutableList<T>
       return true;
     }());
     var changed = false;
-    for (var value in elements.iter) {
-      changed |= _list.remove(value);
+    for (final value in elements.iter) {
+      final removed = _list.remove(value);
+      changed = changed || removed;
     }
     return changed;
   }

--- a/lib/src/collection/impl/map.dart
+++ b/lib/src/collection/impl/map.dart
@@ -2,7 +2,7 @@ import 'package:kt_dart/collection.dart';
 import 'package:kt_dart/src/collection/extension/map_extensions_mixin.dart';
 import 'package:kt_dart/src/util/hash.dart';
 
-class DartMap<K, V> with KtMapExtensionsMixin<K, V> implements KtMap<K, V> {
+class DartMap<K, V>  extends Object with KtMapExtensionsMixin<K, V> implements KtMap<K, V> {
   DartMap([Map<K, V> map = const {}])
       :
 // copy list to prevent external modification

--- a/lib/src/collection/impl/map.dart
+++ b/lib/src/collection/impl/map.dart
@@ -2,7 +2,9 @@ import 'package:kt_dart/collection.dart';
 import 'package:kt_dart/src/collection/extension/map_extensions_mixin.dart';
 import 'package:kt_dart/src/util/hash.dart';
 
-class DartMap<K, V>  extends Object with KtMapExtensionsMixin<K, V> implements KtMap<K, V> {
+class DartMap<K, V> extends Object
+    with KtMapExtensionsMixin<K, V>
+    implements KtMap<K, V> {
   DartMap([Map<K, V> map = const {}])
       :
 // copy list to prevent external modification

--- a/lib/src/collection/impl/map_empty.dart
+++ b/lib/src/collection/impl/map_empty.dart
@@ -1,7 +1,7 @@
 import 'package:kt_dart/collection.dart';
 import 'package:kt_dart/src/collection/extension/map_extensions_mixin.dart';
 
-class EmptyMap<K, V> with KtMapExtensionsMixin<K, V> implements KtMap<K, V> {
+class EmptyMap<K, V> extends Object  with KtMapExtensionsMixin<K, V> implements KtMap<K, V> {
   @override
   Iterable<KtMapEntry<K, V>> get iter => List.unmodifiable([]);
 

--- a/lib/src/collection/impl/map_empty.dart
+++ b/lib/src/collection/impl/map_empty.dart
@@ -1,7 +1,9 @@
 import 'package:kt_dart/collection.dart';
 import 'package:kt_dart/src/collection/extension/map_extensions_mixin.dart';
 
-class EmptyMap<K, V> extends Object  with KtMapExtensionsMixin<K, V> implements KtMap<K, V> {
+class EmptyMap<K, V> extends Object
+    with KtMapExtensionsMixin<K, V>
+    implements KtMap<K, V> {
   @override
   Iterable<KtMapEntry<K, V>> get iter => List.unmodifiable([]);
 

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -3,7 +3,7 @@ import 'package:kt_dart/src/collection/extension/map_extensions_mixin.dart';
 import 'package:kt_dart/src/collection/extension/map_mutable_extensions_mixin.dart';
 import 'package:kt_dart/src/util/hash.dart';
 
-class DartMutableMap<K, V>
+class DartMutableMap<K, V> extends Object
     with KtMapExtensionsMixin<K, V>, KtMutableMapExtensionsMixin<K, V>
     implements KtMutableMap<K, V> {
   DartMutableMap([Map<K, V> map = const {}])

--- a/lib/src/collection/impl/set.dart
+++ b/lib/src/collection/impl/set.dart
@@ -4,7 +4,7 @@ import 'package:kt_dart/src/collection/extension/iterable_extension_mixin.dart';
 import 'package:kt_dart/src/collection/impl/dart_unmodifiable_set_view.dart';
 import 'package:kt_dart/src/util/hash.dart';
 
-class DartSet<T>
+class DartSet<T> extends Object
     with KtIterableExtensionsMixin<T>, KtCollectionExtensionMixin<T>
     implements KtSet<T> {
   DartSet([Iterable<T> iterable = const []])

--- a/lib/src/collection/impl/set_empty.dart
+++ b/lib/src/collection/impl/set_empty.dart
@@ -4,7 +4,7 @@ import 'package:kt_dart/src/collection/extension/iterable_extension_mixin.dart';
 import 'package:kt_dart/src/collection/impl/dart_iterable.dart';
 import 'package:kt_dart/src/collection/impl/dart_unmodifiable_set_view.dart';
 
-class EmptySet<T>
+class EmptySet<T> extends Object
     with KtIterableExtensionsMixin<T>, KtCollectionExtensionMixin<T>
     implements KtSet<T> {
   @override

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -4,7 +4,7 @@ import 'package:kt_dart/src/collection/extension/iterable_extension_mixin.dart';
 import 'package:kt_dart/src/collection/extension/iterable_mutable_extension_mixin.dart';
 import 'package:kt_dart/src/util/hash.dart';
 
-class DartMutableSet<T>
+class DartMutableSet<T> extends Object
     with
         KtIterableExtensionsMixin<T>,
         KtCollectionExtensionMixin<T>,

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -753,7 +753,7 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap,
   });
 }
 
-class ThirdPartyMap<K, V>
+class ThirdPartyMap<K, V> extends Object
     with KtMapExtensionsMixin<K, V>
     implements KtMap<K, V> {
   ThirdPartyMap([Map<K, V> map = const {}])


### PR DESCRIPTION
I noticed that ktdart wasn't working in dart 2.0. Only minor changes where required to fix this.

To prevent such regressions I changed the CI setup to run on all supported dart versions