### PR TITLE
Fix pub publish: Remove analyzer exclusions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ dart:
   - 2.1.0
   - 2.2.0
 with_content_shell: false
-before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 script:
   - set -e
   - pub run tool/reformat.dart

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ script:
   - pub run tool/reformat.dart
   - dartanalyzer --fatal-infos --fatal-warnings ./
   - pub run test test/kt_dart_test.dart
-  - pub global activate coverage
-  - pub global run coverage:collect_coverage --port=8111 -o coverage.json --resume-isolates --wait-paused &
-  - dart --observe=8111 --enable-asserts test/kt_dart_test.dart
-  - pub global run coverage:format_coverage --packages=.packages --report-on lib --in coverage.json --out lcov.info --lcov
+  # don't run coverage on dart 2.3.0 https://github.com/dart-lang/coverage/issues/249
+  - pub --version | grep -q '2.3.0' || pub global activate coverage
+  - pub --version | grep -q '2.3.0' || pub global run coverage:collect_coverage --port=8111 -o coverage.json --resume-isolates --wait-paused &
+  - pub --version | grep -q '2.3.0' || dart --observe=8111 --enable-asserts test/kt_dart_test.dart
+  - pub --version | grep -q '2.3.0' || pub global run coverage:format_coverage --packages=.packages --report-on lib --in coverage.json --out lcov.info --lcov
   - pub publish -n
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ script:
   - pub --version | grep -q '2.3.0' || pub global run coverage:format_coverage --packages=.packages --report-on lib --in coverage.json --out lcov.info --lcov
   - pub publish -n
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  # run coverage report only on dart 2.2.0
+  - pub --version | grep -q '2.2.0' && bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: dart
 sudo: false
+services:
+  - xvfb
 dart:
   - 2.0.0
   - 2.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ script:
   - pub publish -n
 after_success:
   # run coverage report only on dart 2.2.0
-  - pub --version | grep -q '2.2.0' && bash <(curl -s https://codecov.io/bash)
+  - if $(pub --version | grep -q '2.2.0'); then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ dart:
   - 2.0.0
   - 2.1.0
   - 2.2.0
+  - 2.3.0
 with_content_shell: false
 script:
   - set -e
@@ -16,7 +17,6 @@ script:
   - pub global run coverage:collect_coverage --port=8111 -o coverage.json --resume-isolates --wait-paused &
   - dart --observe=8111 --enable-asserts test/kt_dart_test.dart
   - pub global run coverage:format_coverage --packages=.packages --report-on lib --in coverage.json --out lcov.info --lcov
-  # pub is broken in version 2.2.0
-  - pub --version | grep -q '2.2.0' || pub publish -n
+  - pub publish -n
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,4 @@
 analyzer:
-  exclude:
-    - test/**
-    - example/**
 
 # Lint rules and documentation, see http://dart-lang.github.io/linter/lints
 linter:

--- a/example/shop.dart
+++ b/example/shop.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: type_annotate_public_apis
 import 'package:kt_dart/kt.dart';
 
 void main() {
@@ -88,20 +89,20 @@ final teamCity = Product("TeamCity", 299.0);
 final youTrack = Product("YouTrack", 500.0);
 
 //customers
-final lucas = "Lucas";
-final cooper = "Cooper";
-final nathan = "Nathan";
-final reka = "Reka";
-final bajram = "Bajram";
-final asuka = "Asuka";
-final riku = "Riku";
+const lucas = "Lucas";
+const cooper = "Cooper";
+const nathan = "Nathan";
+const reka = "Reka";
+const bajram = "Bajram";
+const asuka = "Asuka";
+const riku = "Riku";
 
 //cities
-final Canberra = City("Canberra");
-final Vancouver = City("Vancouver");
-final Budapest = City("Budapest");
-final Ankara = City("Ankara");
-final Tokyo = City("Tokyo");
+final canberra = City("Canberra");
+final vancouver = City("Vancouver");
+final budapest = City("Budapest");
+final ankara = City("Ankara");
+final tokyo = City("Tokyo");
 
 Customer customer(String name, City city, [List<Order> orders = const []]) =>
     Customer(name, city, listFrom(orders));
@@ -113,26 +114,26 @@ Shop shop(String name, List<Customer> customers) =>
     Shop(name, listFrom(customers));
 
 final jbShop = shop("jb test shop", [
-  customer(lucas, Canberra, [
+  customer(lucas, canberra, [
     order([reSharper]),
     order([reSharper, dotMemory, dotTrace])
   ]),
-  customer(cooper, Canberra),
-  customer(nathan, Vancouver, [
+  customer(cooper, canberra),
+  customer(nathan, vancouver, [
     order([rubyMine, webStorm])
   ]),
-  customer(reka, Budapest, [
+  customer(reka, budapest, [
     order([idea], delivered: false),
     order([idea], delivered: false),
     order([idea])
   ]),
-  customer(bajram, Ankara, [
+  customer(bajram, ankara, [
     order([reSharper])
   ]),
-  customer(asuka, Tokyo, [
+  customer(asuka, tokyo, [
     order([idea])
   ]),
-  customer(riku, Tokyo, [
+  customer(riku, tokyo, [
     order([phpStorm, phpStorm]),
     order([phpStorm])
   ])
@@ -151,9 +152,9 @@ final sortedCustomers = listOf(cooper, nathan, bajram, asuka, lucas, riku, reka)
     .map((it) => jbCustomers[it]);
 
 final groupedByCities = mapFrom({
-  Canberra: listOf(lucas, cooper),
-  Vancouver: listOf(nathan),
-  Budapest: listOf(reka),
-  Ankara: listOf(bajram),
-  Tokyo: listOf(asuka, riku),
+  canberra: listOf(lucas, cooper),
+  vancouver: listOf(nathan),
+  budapest: listOf(reka),
+  ankara: listOf(bajram),
+  tokyo: listOf(asuka, riku),
 }).mapValues((it) => it.value.map((name) => jbCustomers[name]));

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -350,7 +350,7 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
     } else {
       test("drop on iterable returns a iterable", () {
         final iterable = emptyIterable<int>();
-        expect(iterable.drop(1), TypeMatcher<KtList<int>>());
+        expect(iterable.drop(1), const TypeMatcher<KtList<int>>());
       });
     }
     test("drop empty does nothing", () {
@@ -359,7 +359,7 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
     });
     test("drop on iterable returns a iterable", () {
       final iterable = emptyIterable<int>();
-      expect(iterable.drop(1), TypeMatcher<KtList<int>>());
+      expect(iterable.drop(1), const TypeMatcher<KtList<int>>());
     });
 
     test("drop negative, drops nothing", () {
@@ -403,7 +403,7 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
     });
     test("dropWhile on iterable returns a iterable", () {
       final iterable = emptyIterable<int>();
-      expect(iterable.dropWhile((_) => false), TypeMatcher<KtList<int>>());
+      expect(iterable.dropWhile((_) => false), const TypeMatcher<KtList<int>>());
     });
     test("dropWhile doesn't allow null as predicate", () {
       final list = emptyIterable<String>();
@@ -853,12 +853,12 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
 
     test("first throws for no elements", () {
       expect(() => emptyIterable().first(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("finds nothing throws", () {
       expect(() => iterableOf<String>(["a"]).first((it) => it == "b"),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
   });
 
@@ -1301,17 +1301,17 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
 
     test("last throws for no elements", () {
       expect(() => emptyIterable().last(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("finds nothing throws", () {
       expect(() => iterableOf<String>(["a", "b", "c"]).last((it) => it == "x"),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("finds nothing in empty throws", () {
       expect(() => emptyIterable().last((it) => it == "x"),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("returns null when null is the last element", () {

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -403,7 +403,8 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
     });
     test("dropWhile on iterable returns a iterable", () {
       final iterable = emptyIterable<int>();
-      expect(iterable.dropWhile((_) => false), const TypeMatcher<KtList<int>>());
+      expect(
+          iterable.dropWhile((_) => false), const TypeMatcher<KtList<int>>());
     });
     test("dropWhile doesn't allow null as predicate", () {
       final list = emptyIterable<String>();

--- a/test/collection/iterator_test.dart
+++ b/test/collection/iterator_test.dart
@@ -43,18 +43,18 @@ void main() {
 
     test("start index has to be in range (smaller)", () {
       final e = catchException(() => InterOpKtListIterator(["a", "b"], -1));
-      expect(e, TypeMatcher<IndexOutOfBoundsException>());
+      expect(e, const TypeMatcher<IndexOutOfBoundsException>());
     });
 
     test("start index has to be in range (larger)", () {
       final e = catchException(() => InterOpKtListIterator(["a", "b"], 3));
-      expect(e, TypeMatcher<IndexOutOfBoundsException>());
+      expect(e, const TypeMatcher<IndexOutOfBoundsException>());
     });
 
     test("remove is not implemented", () {
       final i = InterOpKtListIterator(["a", "b"], 0);
       final e = catchException(() => i.remove());
-      expect(e, TypeMatcher<UnimplementedError>());
+      expect(e, const TypeMatcher<UnimplementedError>());
     });
 
     test("add adds item to underlying list", () {

--- a/test/collection/list_empty_test.dart
+++ b/test/collection/list_empty_test.dart
@@ -79,7 +79,8 @@ void testEmptyList(KtList<T> Function<T>() emptyList) {
           throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => empty.get(-1),
           throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => empty.get(null), throwsA(const TypeMatcher<ArgumentError>()));
+      expect(
+          () => empty.get(null), throwsA(const TypeMatcher<ArgumentError>()));
     });
 
     test("indexOf always returns -1", () {
@@ -192,9 +193,10 @@ void testEmptyList(KtList<T> Function<T>() emptyList) {
       expect(i.hasPrevious(), false);
       expect(i.nextIndex(), 0);
       expect(i.previousIndex(), -1);
+      expect(() => i.previous(),
+          throwsA(const TypeMatcher<NoSuchElementException>()));
       expect(
-          () => i.previous(), throwsA(const TypeMatcher<NoSuchElementException>()));
-      expect(() => i.next(), throwsA(const TypeMatcher<NoSuchElementException>()));
+          () => i.next(), throwsA(const TypeMatcher<NoSuchElementException>()));
     });
   });
 }

--- a/test/collection/list_empty_test.dart
+++ b/test/collection/list_empty_test.dart
@@ -61,7 +61,7 @@ void testEmptyList(KtList<T> Function<T>() emptyList) {
 
       expect(empty.iterator().hasNext(), isFalse);
       expect(() => empty.iterator().next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("is empty", () {
@@ -74,12 +74,12 @@ void testEmptyList(KtList<T> Function<T>() emptyList) {
       final empty = emptyList();
 
       expect(() => empty.get(0),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => empty.get(1),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => empty.get(-1),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => empty.get(null), throwsA(TypeMatcher<ArgumentError>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => empty.get(null), throwsA(const TypeMatcher<ArgumentError>()));
     });
 
     test("indexOf always returns -1", () {
@@ -147,13 +147,13 @@ void testEmptyList(KtList<T> Function<T>() emptyList) {
       final empty = emptyList<int>();
 
       expect(() => empty.subList(0, 1),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => empty.subList(1, 1),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => empty.subList(-1, -1),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => empty.subList(2, 10),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
     });
 
     test("access dart list", () {
@@ -193,8 +193,8 @@ void testEmptyList(KtList<T> Function<T>() emptyList) {
       expect(i.nextIndex(), 0);
       expect(i.previousIndex(), -1);
       expect(
-          () => i.previous(), throwsA(TypeMatcher<NoSuchElementException>()));
-      expect(() => i.next(), throwsA(TypeMatcher<NoSuchElementException>()));
+          () => i.previous(), throwsA(const TypeMatcher<NoSuchElementException>()));
+      expect(() => i.next(), throwsA(const TypeMatcher<NoSuchElementException>()));
     });
   });
 }

--- a/test/collection/list_extensions_test.dart
+++ b/test/collection/list_extensions_test.dart
@@ -183,16 +183,16 @@ void testList(
 
     test("first throws for no elements", () {
       expect(() => emptySet().first(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
       expect(() => listFrom().first(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("finds nothing throws", () {
       expect(() => setOf<String>("a").first((it) => it == "b"),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
       expect(() => listOf("a").first((it) => it == "b"),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
   });
 

--- a/test/collection/list_mutable_test.dart
+++ b/test/collection/list_mutable_test.dart
@@ -82,7 +82,7 @@ void testList(
 
       expect(iterator.hasNext(), isFalse);
       expect(() => iterator.next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("is list", () {
@@ -99,10 +99,10 @@ void testList(
       expect(list.get(1), equals("b"));
       expect(list.get(2), equals("c"));
       expect(
-          () => list.get(3), throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          () => list.get(3), throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list.get(-1),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list.get(null), throwsA(TypeMatcher<ArgumentError>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list.get(null), throwsA(const TypeMatcher<ArgumentError>()));
     });
 
     test("[] returns elements", () {
@@ -111,9 +111,9 @@ void testList(
       expect(list[0], equals("a"));
       expect(list[1], equals("b"));
       expect(list[2], equals("c"));
-      expect(() => list[3], throwsA(TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list[-1], throwsA(TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list[null], throwsA(TypeMatcher<ArgumentError>()));
+      expect(() => list[3], throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list[-1], throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list[null], throwsA(const TypeMatcher<ArgumentError>()));
     });
 
     test("indexOf return element or -1", () {
@@ -187,14 +187,14 @@ void testList(
       final list = mutableListOf("a", "b", "c");
 
       expect(() => list.subList(0, 10),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list.subList(6, 10),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list.subList(-1, -1),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list.subList(3, 1), throwsA(TypeMatcher<ArgumentError>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list.subList(3, 1), throwsA(const TypeMatcher<ArgumentError>()));
       expect(() => list.subList(2, 10),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
     });
 
     test("add item appends item to end", () {

--- a/test/collection/list_mutable_test.dart
+++ b/test/collection/list_mutable_test.dart
@@ -98,8 +98,8 @@ void testList(
       expect(list.get(0), equals("a"));
       expect(list.get(1), equals("b"));
       expect(list.get(2), equals("c"));
-      expect(
-          () => list.get(3), throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list.get(3),
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list.get(-1),
           throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list.get(null), throwsA(const TypeMatcher<ArgumentError>()));
@@ -111,8 +111,10 @@ void testList(
       expect(list[0], equals("a"));
       expect(list[1], equals("b"));
       expect(list[2], equals("c"));
-      expect(() => list[3], throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list[-1], throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list[3],
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list[-1],
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list[null], throwsA(const TypeMatcher<ArgumentError>()));
     });
 
@@ -192,7 +194,8 @@ void testList(
           throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list.subList(-1, -1),
           throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list.subList(3, 1), throwsA(const TypeMatcher<ArgumentError>()));
+      expect(() => list.subList(3, 1),
+          throwsA(const TypeMatcher<ArgumentError>()));
       expect(() => list.subList(2, 10),
           throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
     });

--- a/test/collection/list_test.dart
+++ b/test/collection/list_test.dart
@@ -290,7 +290,7 @@ void testList(
     });
 
     test("access dart list", () {
-      // ignore: deprecated_member_use_from_same_package
+      // ignore: deprecated_member_use_from_same_package, deprecated_member_use
       final List<String> list = listFrom<String>(["a", "b", "c"]).list;
       expect(list.length, 3);
       expect(list, equals(["a", "b", "c"]));

--- a/test/collection/list_test.dart
+++ b/test/collection/list_test.dart
@@ -137,8 +137,8 @@ void testList(
       expect(list.get(0), equals("a"));
       expect(list.get(1), equals("b"));
       expect(list.get(2), equals("c"));
-      expect(
-          () => list.get(3), throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list.get(3),
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list.get(-1),
           throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list.get(null), throwsA(const TypeMatcher<ArgumentError>()));
@@ -150,8 +150,10 @@ void testList(
       expect(list[0], equals("a"));
       expect(list[1], equals("b"));
       expect(list[2], equals("c"));
-      expect(() => list[3], throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list[-1], throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list[3],
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list[-1],
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list[null], throwsA(const TypeMatcher<ArgumentError>()));
     });
 

--- a/test/collection/list_test.dart
+++ b/test/collection/list_test.dart
@@ -121,7 +121,7 @@ void testList(
 
       expect(iterator.hasNext(), isFalse);
       expect(() => iterator.next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("is list", () {
@@ -138,10 +138,10 @@ void testList(
       expect(list.get(1), equals("b"));
       expect(list.get(2), equals("c"));
       expect(
-          () => list.get(3), throwsA(TypeMatcher<IndexOutOfBoundsException>()));
+          () => list.get(3), throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
       expect(() => list.get(-1),
-          throwsA(TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list.get(null), throwsA(TypeMatcher<ArgumentError>()));
+          throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list.get(null), throwsA(const TypeMatcher<ArgumentError>()));
     });
 
     test("[] returns elements", () {
@@ -150,9 +150,9 @@ void testList(
       expect(list[0], equals("a"));
       expect(list[1], equals("b"));
       expect(list[2], equals("c"));
-      expect(() => list[3], throwsA(TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list[-1], throwsA(TypeMatcher<IndexOutOfBoundsException>()));
-      expect(() => list[null], throwsA(TypeMatcher<ArgumentError>()));
+      expect(() => list[3], throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list[-1], throwsA(const TypeMatcher<IndexOutOfBoundsException>()));
+      expect(() => list[null], throwsA(const TypeMatcher<ArgumentError>()));
     });
 
     test("indexOf returns first element or -1", () {

--- a/test/collection/map_empty_test.dart
+++ b/test/collection/map_empty_test.dart
@@ -64,14 +64,14 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap, {bool mutable = true}) {
       final empty = emptyMap();
       expect(empty.values.iterator().hasNext(), isFalse);
       expect(() => empty.values.iterator().next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("keys iterator has no next", () {
       final empty = emptyMap();
       expect(empty.keys.iterator().hasNext(), isFalse);
       expect(() => empty.keys.iterator().next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("is empty", () {

--- a/test/collection/map_mutable_test.dart
+++ b/test/collection/map_mutable_test.dart
@@ -81,7 +81,7 @@ void testMutableMap(
       });
 
       // TODO exchange error check with assertion once https://github.com/passsy/dart_kollection/issues/55 has been fixed
-      expect(e, TypeMatcher<UnimplementedError>());
+      expect(e, const TypeMatcher<UnimplementedError>());
       // expect(
       //    pokemon,
       //     mapFrom({

--- a/test/collection/set_empty_test.dart
+++ b/test/collection/set_empty_test.dart
@@ -48,7 +48,7 @@ void testEmptySet(KtSet<T> Function<T>() emptySet, {bool mutable = false}) {
       final iterator = emptySet().iterator();
       expect(iterator.hasNext(), isFalse);
       expect(() => iterator.next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("contains nothing", () {

--- a/test/collection/set_empty_test.dart
+++ b/test/collection/set_empty_test.dart
@@ -81,7 +81,7 @@ void testEmptySet(KtSet<T> Function<T>() emptySet, {bool mutable = false}) {
       test("empty set set allows mutation", () {
         final ktSet = emptySet();
         expect(ktSet.isEmpty(), isTrue);
-        // ignore: deprecated_member_use_from_same_package
+        // ignore: deprecated_member_use_from_same_package, deprecated_member_use
         final dartSet = ktSet.set;
         dartSet.add("asdf");
         expect(dartSet.length, 1);
@@ -100,7 +100,7 @@ void testEmptySet(KtSet<T> Function<T>() emptySet, {bool mutable = false}) {
         final ktSet = emptySet();
         expect(ktSet.isEmpty(), isTrue);
         final e =
-            // ignore: deprecated_member_use_from_same_package
+            // ignore: deprecated_member_use_from_same_package, deprecated_member_use
             catchException<UnsupportedError>(() => ktSet.set.add("asdf"));
         expect(e.message, contains("unmodifiable"));
       });

--- a/test/collection/set_mutable_test.dart
+++ b/test/collection/set_mutable_test.dart
@@ -97,7 +97,7 @@ void testMutableSet(
   test("using the internal dart set allows mutation - empty", () {
     final kset = mutableSetOf();
     expect(kset.isEmpty(), isTrue);
-    // ignore: deprecated_member_use_from_same_package
+    // ignore: deprecated_member_use_from_same_package, deprecated_member_use
     kset.set.add("asdf");
     // unchanged
     expect(kset.isEmpty(), isFalse);
@@ -107,7 +107,7 @@ void testMutableSet(
   test("using the internal dart set allows mutation", () {
     final kset = mutableSetOf("a");
     expect(kset, setOf("a"));
-    // ignore: deprecated_member_use_from_same_package
+    // ignore: deprecated_member_use_from_same_package, deprecated_member_use
     kset.set.add("b");
     // unchanged
     expect(kset, setOf("a", "b"));

--- a/test/collection/set_mutable_test.dart
+++ b/test/collection/set_mutable_test.dart
@@ -76,7 +76,7 @@ void testMutableSet(
       expect(iterator.next(), "c");
       expect(iterator.hasNext(), isFalse);
       final e = catchException(() => iterator.next());
-      expect(e, TypeMatcher<NoSuchElementException>());
+      expect(e, const TypeMatcher<NoSuchElementException>());
     });
   } else {
     test("throws at end", () {
@@ -90,7 +90,7 @@ void testMutableSet(
       iterator.next();
       expect(iterator.hasNext(), isFalse);
       final e = catchException(() => iterator.next());
-      expect(e, TypeMatcher<NoSuchElementException>());
+      expect(e, const TypeMatcher<NoSuchElementException>());
     });
   }
 

--- a/test/collection/set_test.dart
+++ b/test/collection/set_test.dart
@@ -164,7 +164,7 @@ void testSet(
     });
 
     test("access dart set", () {
-      // ignore: deprecated_member_use_from_same_package
+      // ignore: deprecated_member_use_from_same_package, deprecated_member_use
       final Set<String> set = setOf<String>("a", "b", "c").set;
       expect(set.length, 3);
       expect(set, equals(Set.from(["a", "b", "c"])));

--- a/test/collection/set_test.dart
+++ b/test/collection/set_test.dart
@@ -82,7 +82,7 @@ void testSet(
       final iterator = setOf().iterator();
       expect(iterator.hasNext(), isFalse);
       expect(() => iterator.next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("has no elements", () {
@@ -105,7 +105,7 @@ void testSet(
       final iterator = set.iterator();
       expect(iterator.hasNext(), isFalse);
       expect(() => iterator.next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("iterator with 1 element has 1 next", () {
@@ -116,7 +116,7 @@ void testSet(
 
       expect(iterator.hasNext(), isFalse);
       expect(() => iterator.next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("iterator with items", () {
@@ -132,7 +132,7 @@ void testSet(
 
       expect(iterator.hasNext(), isFalse);
       expect(() => iterator.next(),
-          throwsA(TypeMatcher<NoSuchElementException>()));
+          throwsA(const TypeMatcher<NoSuchElementException>()));
     });
 
     test("is empty", () {

--- a/test/test/assert_dart.dart
+++ b/test/test/assert_dart.dart
@@ -6,6 +6,7 @@ T catchException<T>(Function block) {
     block();
     fail("block did not throw");
   } catch (e, stack) {
+    // ignore: prefer_const_constructors
     expect(e, TypeMatcher<T>(), reason: stack.toString());
     return e as T;
   }


### PR DESCRIPTION
This fix allows running `pub publish` with dart 2.2 and 2.3 again (see https://github.com/dart-lang/pub/issues/2032)