### PR TITLE
Embrace const where possible

### DIFF
--- a/example/syntax_comparison.dart
+++ b/example/syntax_comparison.dart
@@ -45,7 +45,7 @@ void main() {
 
   /// List
   // Create immutable lists
-  const KtList<int>.empty();
+  KtList<int>.empty();
   KtList.of(1, 2, 3, 4, 5);
   KtList.from([1, 2, 3, 4, 5]);
 
@@ -56,7 +56,7 @@ void main() {
 
   /// Set
   // Create immutable sets
-  const KtSet<int>.empty();
+  KtSet<int>.empty();
   KtSet.of(1, 2, 3, 4, 5);
   KtSet.from([1, 2, 3, 4, 5]);
 
@@ -77,7 +77,7 @@ void main() {
 
   /// Map
   // Create immutable maps
-  const KtMap.empty();
+  KtMap.empty();
   KtMap.from({1: "a", 2: "b"});
 
   // Create mutable maps

--- a/example/syntax_comparison.dart
+++ b/example/syntax_comparison.dart
@@ -45,7 +45,7 @@ void main() {
 
   /// List
   // Create immutable lists
-  KtList<int>.empty();
+  const KtList<int>.empty();
   KtList.of(1, 2, 3, 4, 5);
   KtList.from([1, 2, 3, 4, 5]);
 
@@ -56,7 +56,7 @@ void main() {
 
   /// Set
   // Create immutable sets
-  KtSet<int>.empty();
+  const KtSet<int>.empty();
   KtSet.of(1, 2, 3, 4, 5);
   KtSet.from([1, 2, 3, 4, 5]);
 
@@ -76,6 +76,10 @@ void main() {
   KtLinkedSet.from([1, 2, 3, 4, 5]);
 
   /// Map
+  // Create immutable maps
+  const KtMap.empty();
+  KtMap.from({1: "a", 2: "b"});
+
   // Create mutable maps
   KtMutableMap<int, String>.empty();
   KtMutableMap.from({1: "a", 2: "b"});

--- a/lib/src/collection/collections.dart
+++ b/lib/src/collection/collections.dart
@@ -23,7 +23,7 @@ KtList<T> listFrom<T>([Iterable<T> elements = const []]) =>
     KtList.from(elements);
 
 /// Returns an empty read-only list.
-KtList<T> emptyList<T>() => KtList.empty();
+KtList<T> emptyList<T>() => KtList<T>.empty();
 
 /// Returns a new mutable list of given elements.
 ///
@@ -52,7 +52,7 @@ KtMutableList<T> mutableListFrom<T>([Iterable<T> elements = const []]) =>
 KtMap<K, V> mapFrom<K, V>([Map<K, V> map = const {}]) => KtMap.from(map);
 
 /// Returns an empty read-only map of specified type.
-KtMap<K, V> emptyMap<K, V>() => KtMap.empty();
+KtMap<K, V> emptyMap<K, V>() => KtMap<K, V>.empty();
 
 /// Returns a new [KtMutableMap] with the specified contents, given as a list of pairs
 /// where the first component is the key and the second is the value.
@@ -99,7 +99,7 @@ KtSet<T> setOf<T>(
 KtSet<T> setFrom<T>([Iterable<T> elements = const []]) => KtSet.from(elements);
 
 /// Returns an empty read-only set.
-KtSet<T> emptySet<T>() => KtSet.empty();
+KtSet<T> emptySet<T>() => KtSet<T>.empty();
 
 /// Returns a new [KtMutableSet] based on [LinkedHashSet] with the given elements.
 /// Elements of the set are iterated in the order they were specified.

--- a/lib/src/collection/extension/collection_extension_mixin.dart
+++ b/lib/src/collection/extension/collection_extension_mixin.dart
@@ -3,7 +3,7 @@ import "dart:math" as math show Random;
 import "package:kt_dart/collection.dart";
 
 abstract class KtCollectionExtensionMixin<T>
-    implements KCollectionExtension<T>, KtCollection<T> {
+    implements KtCollectionExtension<T>, KtCollection<T> {
   @override
   KtMutableList<T> toMutableList() => KtMutableList<T>.from(iter);
 

--- a/lib/src/collection/extension/iterable_extension_mixin.dart
+++ b/lib/src/collection/extension/iterable_extension_mixin.dart
@@ -448,14 +448,14 @@ abstract class KtIterableExtensionsMixin<T>
     if (predicate == null) {
       final i = iterator();
       if (!i.hasNext()) {
-        throw NoSuchElementException("Collection is empty");
+        throw const NoSuchElementException("Collection is empty");
       }
       return i.next();
     } else {
       for (final element in iter) {
         if (predicate(element)) return element;
       }
-      throw NoSuchElementException(
+      throw const NoSuchElementException(
           "Collection contains no element matching the predicate.");
     }
   }
@@ -703,7 +703,7 @@ abstract class KtIterableExtensionsMixin<T>
       if (this is KtList) return (this as KtList<T>).last();
       final i = iterator();
       if (!i.hasNext()) {
-        throw NoSuchElementException("Collection is empty");
+        throw const NoSuchElementException("Collection is empty");
       }
       var last = i.next();
       while (i.hasNext()) {
@@ -720,7 +720,7 @@ abstract class KtIterableExtensionsMixin<T>
         }
       }
       if (!found) {
-        throw NoSuchElementException(
+        throw const NoSuchElementException(
             "Collection contains no element matching the predicate.");
       }
       return last;
@@ -1141,7 +1141,7 @@ abstract class KtIterableExtensionsMixin<T>
     if (predicate == null) {
       final i = iterator();
       if (!i.hasNext()) {
-        throw NoSuchElementException("Collection is empty.");
+        throw const NoSuchElementException("Collection is empty.");
       }
       final single = i.next();
       if (i.hasNext()) {
@@ -1162,7 +1162,7 @@ abstract class KtIterableExtensionsMixin<T>
         }
       }
       if (!found) {
-        throw NoSuchElementException(
+        throw const NoSuchElementException(
             "Collection contains no element matching the predicate.");
       }
       return single;

--- a/lib/src/collection/extension/list_extension_mixin.dart
+++ b/lib/src/collection/extension/list_extension_mixin.dart
@@ -53,13 +53,13 @@ abstract class KtListExtensionsMixin<T>
   @override
   T first([bool Function(T) predicate]) {
     if (predicate == null) {
-      if (isEmpty()) throw NoSuchElementException("List is empty.");
+      if (isEmpty()) throw const NoSuchElementException("List is empty.");
       return get(0);
     } else {
       for (final element in iter) {
         if (predicate(element)) return element;
       }
-      throw NoSuchElementException(
+      throw const NoSuchElementException(
           "Collection contains no element matching the predicate.");
     }
   }
@@ -122,12 +122,12 @@ abstract class KtListExtensionsMixin<T>
   @override
   T last([bool Function(T) predicate]) {
     if (predicate == null) {
-      if (isEmpty()) throw NoSuchElementException("List is empty.");
+      if (isEmpty()) throw const NoSuchElementException("List is empty.");
       return get(lastIndex);
     } else {
       final i = listIterator(size);
       if (!i.hasPrevious()) {
-        throw NoSuchElementException("Collection is empty");
+        throw const NoSuchElementException("Collection is empty");
       }
       while (i.hasPrevious()) {
         final element = i.previous();
@@ -135,7 +135,7 @@ abstract class KtListExtensionsMixin<T>
           return element;
         }
       }
-      throw NoSuchElementException(
+      throw const NoSuchElementException(
           "Collection contains no element matching the predicate.");
     }
   }
@@ -182,7 +182,7 @@ abstract class KtListExtensionsMixin<T>
     if (predicate == null) {
       switch (size) {
         case 0:
-          throw NoSuchElementException("List is empty");
+          throw const NoSuchElementException("List is empty");
         case 1:
           return get(0);
         default:
@@ -202,7 +202,7 @@ abstract class KtListExtensionsMixin<T>
         }
       }
       if (!found) {
-        throw NoSuchElementException(
+        throw const NoSuchElementException(
             "Collection contains no element matching the predicate.");
       }
       return single;

--- a/lib/src/collection/extension/list_extension_mixin.dart
+++ b/lib/src/collection/extension/list_extension_mixin.dart
@@ -141,9 +141,6 @@ abstract class KtListExtensionsMixin<T>
   }
 
   @override
-  int get lastIndex => size - 1;
-
-  @override
   S reduceRight<S>(S Function(T, S acc) operation) {
     assert(() {
       if (operation == null) throw ArgumentError("operation can't be null");

--- a/lib/src/collection/impl/iterator.dart
+++ b/lib/src/collection/impl/iterator.dart
@@ -16,7 +16,7 @@ class InterOpKIterator<T> implements KtIterator<T> {
 
   @override
   T next() {
-    if (!_hasNext) throw NoSuchElementException();
+    if (!_hasNext) throw const NoSuchElementException();
     final e = _nextValue;
     _hasNext = iterator.moveNext();
     _nextValue = iterator.current;
@@ -42,7 +42,7 @@ class InterOpKtListIterator<T>
   @override
   T next() {
     final i = _cursor;
-    if (i >= _list.length) throw NoSuchElementException();
+    if (i >= _list.length) throw const NoSuchElementException();
     _cursor = i + 1;
     return _list[_lastRet = i];
   }
@@ -65,7 +65,7 @@ class InterOpKtListIterator<T>
 
   @override
   T previous() {
-    if (!hasPrevious()) throw NoSuchElementException();
+    if (!hasPrevious()) throw const NoSuchElementException();
     return _list[--_cursor];
   }
 
@@ -83,7 +83,7 @@ class InterOpKtListIterator<T>
   @override
   void set(T element) {
     if (_lastRet < 0) {
-      throw IndexOutOfBoundsException(
+      throw const IndexOutOfBoundsException(
           "illegal cursor state -1. next() or previous() not called");
     }
     _list.replaceRange(_lastRet, _lastRet + 1, [element]);

--- a/lib/src/collection/impl/list.dart
+++ b/lib/src/collection/impl/list.dart
@@ -81,6 +81,9 @@ class DartList<T> extends Object
   int get size => _list.length;
 
   @override
+  int get lastIndex => size - 1;
+
+  @override
   KtList<T> subList(int fromIndex, int toIndex) {
     assert(() {
       if (fromIndex == null) throw ArgumentError("fromIndex can't be null");

--- a/lib/src/collection/impl/list_empty.dart
+++ b/lib/src/collection/impl/list_empty.dart
@@ -10,7 +10,7 @@ class EmptyList<T> extends Object
         KtCollectionExtensionMixin<T>,
         KtListExtensionsMixin<T>
     implements KtList<T> {
-  const EmptyList();
+  EmptyList();
 
   @override
   List<T> get list => List.unmodifiable(const []);

--- a/lib/src/collection/impl/list_empty.dart
+++ b/lib/src/collection/impl/list_empty.dart
@@ -10,6 +10,8 @@ class EmptyList<T> extends Object
         KtCollectionExtensionMixin<T>,
         KtListExtensionsMixin<T>
     implements KtList<T> {
+  const EmptyList();
+
   @override
   List<T> get list => List.unmodifiable([]);
 

--- a/lib/src/collection/impl/list_empty.dart
+++ b/lib/src/collection/impl/list_empty.dart
@@ -73,6 +73,9 @@ class EmptyList<T> extends Object
   int get size => 0;
 
   @override
+  int get lastIndex => -1;
+
+  @override
   KtList<T> subList(int fromIndex, int toIndex) {
     assert(() {
       if (fromIndex == null) throw ArgumentError("fromIndex can't be null");

--- a/lib/src/collection/impl/list_empty.dart
+++ b/lib/src/collection/impl/list_empty.dart
@@ -13,10 +13,10 @@ class EmptyList<T> extends Object
   const EmptyList();
 
   @override
-  List<T> get list => List.unmodifiable([]);
+  List<T> get list => List.unmodifiable(const []);
 
   @override
-  List<T> asList() => List.unmodifiable([]);
+  List<T> asList() => List.unmodifiable(const []);
 
   @override
   bool contains(T element) => false;

--- a/lib/src/collection/impl/list_empty.dart
+++ b/lib/src/collection/impl/list_empty.dart
@@ -57,7 +57,7 @@ class EmptyList<T> extends Object
   bool isEmpty() => true;
 
   @override
-  KtIterator<T> iterator() => _EmptyIterator();
+  KtIterator<T> iterator() => _EmptyIterator<T>();
 
   @override
   int lastIndexOf(T element) => -1;
@@ -68,7 +68,7 @@ class EmptyList<T> extends Object
       if (index == null) throw ArgumentError("index can't be null");
       return true;
     }());
-    return _EmptyIterator();
+    return _EmptyIterator<T>();
   }
 
   @override
@@ -102,7 +102,7 @@ class EmptyList<T> extends Object
   Iterable<T> get iter => EmptyDartIterable();
 }
 
-class _EmptyIterator<T> extends KtListIterator<T> {
+class _EmptyIterator<T> implements KtListIterator<T> {
   @override
   bool hasNext() => false;
 

--- a/lib/src/collection/impl/list_empty.dart
+++ b/lib/src/collection/impl/list_empty.dart
@@ -106,7 +106,7 @@ class _EmptyIterator<T> extends KtListIterator<T> {
 
   @override
   T next() {
-    throw NoSuchElementException();
+    throw const NoSuchElementException();
   }
 
   @override
@@ -114,7 +114,7 @@ class _EmptyIterator<T> extends KtListIterator<T> {
 
   @override
   T previous() {
-    throw NoSuchElementException();
+    throw const NoSuchElementException();
   }
 
   @override

--- a/lib/src/collection/impl/list_mutable.dart
+++ b/lib/src/collection/impl/list_mutable.dart
@@ -85,6 +85,9 @@ class DartMutableList<T> extends Object
   int get size => _list.length;
 
   @override
+  int get lastIndex => size - 1;
+
+  @override
   bool add(T element) {
     _list.add(element);
     return true;

--- a/lib/src/collection/impl/map_empty.dart
+++ b/lib/src/collection/impl/map_empty.dart
@@ -4,7 +4,7 @@ import "package:kt_dart/src/collection/extension/map_extensions_mixin.dart";
 class EmptyMap<K, V> extends Object
     with KtMapExtensionsMixin<K, V>
     implements KtMap<K, V> {
-  const EmptyMap();
+  EmptyMap();
 
   @override
   Iterable<KtMapEntry<K, V>> get iter => List.unmodifiable(const []);

--- a/lib/src/collection/impl/map_empty.dart
+++ b/lib/src/collection/impl/map_empty.dart
@@ -4,6 +4,8 @@ import "package:kt_dart/src/collection/extension/map_extensions_mixin.dart";
 class EmptyMap<K, V> extends Object
     with KtMapExtensionsMixin<K, V>
     implements KtMap<K, V> {
+  const EmptyMap();
+
   @override
   Iterable<KtMapEntry<K, V>> get iter => List.unmodifiable([]);
 

--- a/lib/src/collection/impl/map_empty.dart
+++ b/lib/src/collection/impl/map_empty.dart
@@ -7,10 +7,10 @@ class EmptyMap<K, V> extends Object
   const EmptyMap();
 
   @override
-  Iterable<KtMapEntry<K, V>> get iter => List.unmodifiable([]);
+  Iterable<KtMapEntry<K, V>> get iter => List.unmodifiable(const []);
 
   @override
-  Map<K, V> asMap() => Map.unmodifiable({});
+  Map<K, V> asMap() => Map.unmodifiable(const {});
 
   @override
   V operator [](K key) => null;

--- a/lib/src/collection/impl/set.dart
+++ b/lib/src/collection/impl/set.dart
@@ -84,7 +84,7 @@ class _DartToKIterator<T> extends KtIterator<T> {
 
   @override
   T next() {
-    if (!_hasNext) throw NoSuchElementException();
+    if (!_hasNext) throw const NoSuchElementException();
     final e = nextValue;
     _hasNext = iterator.moveNext();
     nextValue = iterator.current;

--- a/lib/src/collection/impl/set_empty.dart
+++ b/lib/src/collection/impl/set_empty.dart
@@ -7,7 +7,7 @@ import "package:kt_dart/src/collection/impl/dart_unmodifiable_set_view.dart";
 class EmptySet<T> extends Object
     with KtIterableExtensionsMixin<T>, KtCollectionExtensionMixin<T>
     implements KtSet<T> {
-  const EmptySet();
+  EmptySet();
 
   @override
   // TODO replace with const set literal {}

--- a/lib/src/collection/impl/set_empty.dart
+++ b/lib/src/collection/impl/set_empty.dart
@@ -10,6 +10,7 @@ class EmptySet<T> extends Object
   const EmptySet();
 
   @override
+  // TODO replace with const set literal {}
   Set<T> get set => UnmodifiableSetView(Set());
 
   @override

--- a/lib/src/collection/impl/set_empty.dart
+++ b/lib/src/collection/impl/set_empty.dart
@@ -53,6 +53,6 @@ class _EmptyIterator<T> extends KtIterator<T> {
 
   @override
   T next() {
-    throw NoSuchElementException();
+    throw const NoSuchElementException();
   }
 }

--- a/lib/src/collection/impl/set_empty.dart
+++ b/lib/src/collection/impl/set_empty.dart
@@ -49,7 +49,7 @@ class EmptySet<T> extends Object
   Iterable<T> get iter => EmptyDartIterable();
 }
 
-class _EmptyIterator<T> extends KtIterator<T> {
+class _EmptyIterator<T> implements KtIterator<T> {
   @override
   bool hasNext() => false;
 

--- a/lib/src/collection/impl/set_empty.dart
+++ b/lib/src/collection/impl/set_empty.dart
@@ -7,6 +7,8 @@ import "package:kt_dart/src/collection/impl/dart_unmodifiable_set_view.dart";
 class EmptySet<T> extends Object
     with KtIterableExtensionsMixin<T>, KtCollectionExtensionMixin<T>
     implements KtSet<T> {
+  const EmptySet();
+
   @override
   Set<T> get set => UnmodifiableSetView(Set());
 

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -136,7 +136,7 @@ class _MutableSetIterator<T> extends KtMutableIterator<T> {
 
   @override
   T next() {
-    if (!_hasNext) throw NoSuchElementException();
+    if (!_hasNext) throw const NoSuchElementException();
     final e = nextValue;
     _hasNext = _iterator.moveNext();
     nextValue = _iterator.current;

--- a/lib/src/collection/kt_collection.dart
+++ b/lib/src/collection/kt_collection.dart
@@ -6,7 +6,7 @@ import "package:kt_dart/collection.dart";
 /// read/write access is supported through the [KtMutableCollection] interface.
 /// @param E the type of elements contained in the collection. The collection is covariant on its element type.
 abstract class KtCollection<T>
-    implements KtIterable<T>, KCollectionExtension<T> {
+    implements KtIterable<T>, KtCollectionExtension<T> {
   // Query Operations
   /// Returns the size of the collection.
   int get size;
@@ -29,7 +29,7 @@ abstract class KtCollection<T>
   KtList<T> drop(int n);
 }
 
-abstract class KCollectionExtension<T> {
+abstract class KtCollectionExtension<T> {
   /// Returns `true` if the collection is not empty.
   bool isNotEmpty();
 

--- a/lib/src/collection/kt_list.dart
+++ b/lib/src/collection/kt_list.dart
@@ -16,7 +16,7 @@ abstract class KtList<T> implements KtCollection<T>, KtListExtension<T> {
       if (elements == null) throw ArgumentError("elements can't be null");
       return true;
     }());
-    if (elements.isEmpty) return EmptyList();
+    if (elements.isEmpty) return EmptyList<T>();
     return DartList(elements);
   }
 

--- a/lib/src/collection/kt_list.dart
+++ b/lib/src/collection/kt_list.dart
@@ -47,6 +47,9 @@ abstract class KtList<T> implements KtCollection<T>, KtListExtension<T> {
   @override
   int get size;
 
+  /// Returns the index of the last item in the list or -1 if the list is empty.
+  int get lastIndex => size - 1;
+
   /// Returns a read-only dart:core [List]
   ///
   /// This method can be used to interop between the dart:collection and the
@@ -149,9 +152,6 @@ abstract class KtListExtension<T> {
   /// @throws [NoSuchElementException] if no such element is found.
   @nonNull
   T last([bool Function(T) predicate]);
-
-  /// Returns the index of the last item in the list or -1 if the list is empty.
-  int get lastIndex;
 
   /// Accumulates value starting with last element and applying [operation] from right to left to each element and current accumulator value.
   S reduceRight<S>(S Function(T, S acc) operation);

--- a/lib/src/collection/kt_list.dart
+++ b/lib/src/collection/kt_list.dart
@@ -8,7 +8,7 @@ import "package:kt_dart/src/util/arguments.dart";
 /// @param [T] the type of elements contained in the list. The list is covariant on its element type.
 abstract class KtList<T> implements KtCollection<T>, KtListExtension<T> {
   /// Returns an empty read-only list.
-  const factory KtList.empty() = EmptyList<T>;
+  factory KtList.empty() = EmptyList<T>;
 
   /// Returns a new read-only list based on [elements].
   factory KtList.from([@nonNull Iterable<T> elements = const []]) {

--- a/lib/src/collection/kt_list.dart
+++ b/lib/src/collection/kt_list.dart
@@ -8,7 +8,7 @@ import "package:kt_dart/src/util/arguments.dart";
 /// @param [T] the type of elements contained in the list. The list is covariant on its element type.
 abstract class KtList<T> implements KtCollection<T>, KtListExtension<T> {
   /// Returns an empty read-only list.
-  factory KtList.empty() => EmptyList<T>();
+  const factory KtList.empty() = EmptyList<T>;
 
   /// Returns a new read-only list based on [elements].
   factory KtList.from([@nonNull Iterable<T> elements = const []]) {

--- a/lib/src/collection/kt_map.dart
+++ b/lib/src/collection/kt_map.dart
@@ -10,7 +10,7 @@ import "package:kt_dart/src/collection/impl/map_empty.dart";
 ///          can accept key as a parameter (of [containsKey] for example) and return it in [keys] set.
 /// @param V the type of map values. The map is covariant on its value type.
 abstract class KtMap<K, V> implements KtMapExtension<K, V> {
-  factory KtMap.empty() => EmptyMap<K, V>();
+  const factory KtMap.empty() = EmptyMap<K, V>;
 
   factory KtMap.from([@nonNull Map<K, V> map = const {}]) {
     assert(() {

--- a/lib/src/collection/kt_map.dart
+++ b/lib/src/collection/kt_map.dart
@@ -10,7 +10,7 @@ import "package:kt_dart/src/collection/impl/map_empty.dart";
 ///          can accept key as a parameter (of [containsKey] for example) and return it in [keys] set.
 /// @param V the type of map values. The map is covariant on its value type.
 abstract class KtMap<K, V> implements KtMapExtension<K, V> {
-  const factory KtMap.empty() = EmptyMap<K, V>;
+  factory KtMap.empty() = EmptyMap<K, V>;
 
   factory KtMap.from([@nonNull Map<K, V> map = const {}]) {
     assert(() {

--- a/lib/src/collection/kt_set.dart
+++ b/lib/src/collection/kt_set.dart
@@ -9,7 +9,7 @@ import "package:kt_dart/src/util/arguments.dart";
 /// @param E the type of elements contained in the set. The set is covariant on its element type.
 abstract class KtSet<T> implements KtCollection<T> {
   /// Returns an empty read-only set.
-  factory KtSet.empty() => EmptySet<T>();
+  const factory KtSet.empty() = EmptySet<T>;
 
   /// Returns a new read-only set based on [elements].
   factory KtSet.from([@nonNull Iterable<T> elements = const []]) {

--- a/lib/src/collection/kt_set.dart
+++ b/lib/src/collection/kt_set.dart
@@ -9,7 +9,7 @@ import "package:kt_dart/src/util/arguments.dart";
 /// @param E the type of elements contained in the set. The set is covariant on its element type.
 abstract class KtSet<T> implements KtCollection<T> {
   /// Returns an empty read-only set.
-  const factory KtSet.empty() = EmptySet<T>;
+  factory KtSet.empty() = EmptySet<T>;
 
   /// Returns a new read-only set based on [elements].
   factory KtSet.from([@nonNull Iterable<T> elements = const []]) {

--- a/lib/src/collection/tuples.dart
+++ b/lib/src/collection/tuples.dart
@@ -8,7 +8,7 @@
 /// @property first First value.
 /// @property second Second value.
 class KtPair<A, B> {
-  KtPair(this.first, this.second);
+  const KtPair(this.first, this.second);
 
   final A first;
   final B second;
@@ -40,7 +40,7 @@ class KtPair<A, B> {
 /// @property second Second value.
 /// @property third Third value.
 class KtTriple<A, B, C> {
-  KtTriple(this.first, this.second, this.third);
+  const KtTriple(this.first, this.second, this.third);
 
   final A first;
   final B second;

--- a/lib/src/exception/exceptions.dart
+++ b/lib/src/exception/exceptions.dart
@@ -1,5 +1,5 @@
 class IndexOutOfBoundsException implements Exception {
-  IndexOutOfBoundsException([this.message]);
+  const IndexOutOfBoundsException([this.message]);
 
   final String message;
 
@@ -10,7 +10,7 @@ class IndexOutOfBoundsException implements Exception {
 }
 
 class NoSuchElementException implements Exception {
-  NoSuchElementException([this.message]);
+  const NoSuchElementException([this.message]);
 
   final String message;
 

--- a/lib/src/util/arguments.dart
+++ b/lib/src/util/arguments.dart
@@ -38,7 +38,7 @@ List<T> argsToList<T>(
   } else if (arg0 != null) {
     return [arg0];
   } else {
-    return [];
+    return const [];
   }
 
   if (args.contains(null)) {

--- a/test/collection/collections_test.dart
+++ b/test/collection/collections_test.dart
@@ -9,10 +9,10 @@ void main() {
 void dartLikeSyntax() {
   group("emptyList", () {
     test("basic creation", () {
-      const list = KtList<String>.empty();
+      final list = KtList<String>.empty();
       expect(list.size, 0);
       expect(list.hashCode, 1);
-      expect(list, const KtList.empty());
+      expect(list, KtList.empty());
       expect(list, KtList.of());
       final emptyMutable = KtMutableList.of("a")..remove("a");
       expect(list.hashCode, emptyMutable.hashCode);
@@ -22,11 +22,11 @@ void dartLikeSyntax() {
 
   group("listFrom", () {
     test("empty", () {
-      const list = KtList<String>.empty();
+      final list = KtList<String>.empty();
       expect(list.size, 0);
       expect(list.hashCode, 1);
       expect(list, listFrom());
-      expect(list, const KtList<String>.empty());
+      expect(list, KtList<String>.empty());
       final emptyMutable = KtMutableList.of("a")..remove("a");
       expect(list.hashCode, emptyMutable.hashCode);
       expect(list, emptyMutable);

--- a/test/collection/collections_test.dart
+++ b/test/collection/collections_test.dart
@@ -9,10 +9,10 @@ void main() {
 void dartLikeSyntax() {
   group("emptyList", () {
     test("basic creation", () {
-      final list = KtList<String>.empty();
+      const list = KtList<String>.empty();
       expect(list.size, 0);
       expect(list.hashCode, 1);
-      expect(list, KtList.empty());
+      expect(list, const KtList.empty());
       expect(list, KtList.of());
       final emptyMutable = KtMutableList.of("a")..remove("a");
       expect(list.hashCode, emptyMutable.hashCode);
@@ -22,11 +22,11 @@ void dartLikeSyntax() {
 
   group("listFrom", () {
     test("empty", () {
-      final list = KtList<String>.empty();
+      const list = KtList<String>.empty();
       expect(list.size, 0);
       expect(list.hashCode, 1);
       expect(list, listFrom());
-      expect(list, KtList<String>.empty());
+      expect(list, const KtList<String>.empty());
       final emptyMutable = KtMutableList.of("a")..remove("a");
       expect(list.hashCode, emptyMutable.hashCode);
       expect(list, emptyMutable);

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -1257,7 +1257,7 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
         expect(s, "a, b, c");
       });
       test("joinToString calls childs toString", () {
-        final s = iterableOf([listOf(1, 2, 3), KtPair("a", "b"), "test"])
+        final s = iterableOf([listOf(1, 2, 3), const KtPair("a", "b"), "test"])
             .joinToString();
         expect(s, "[1, 2, 3], (a, b), test");
       });
@@ -2260,7 +2260,7 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
   group("zip", () {
     test("to pair", () {
       final result = iterableOf([1, 2, 3, 4, 5]).zip(iterableOf(["a", "b"]));
-      expect(result, listFrom([KtPair(1, "a"), KtPair(2, "b")]));
+      expect(result, listFrom(const [KtPair(1, "a"), KtPair(2, "b")]));
     });
     test("transform", () {
       final result = iterableOf([1, 2, 3, 4, 5])
@@ -2291,7 +2291,7 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
   group("zipWithNext", () {
     test("zipWithNext", () {
       final result = iterableOf([1, 2, 3]).zipWithNext();
-      expect(result, listOf(KtPair(1, 2), KtPair(2, 3)));
+      expect(result, listOf(const KtPair(1, 2), const KtPair(2, 3)));
     });
   });
 

--- a/test/collection/list_empty_test.dart
+++ b/test/collection/list_empty_test.dart
@@ -15,6 +15,10 @@ void main() {
   });
   group("KtList.empty", () {
     testEmptyList(<T>() => KtList<T>.empty());
+    test("const constructor", () {
+      const list = KtList<String>.empty();
+      expect(list.runtimeType.toString(), contains("<String>"));
+    });
   });
   group("KtList.of", () {
     testEmptyList(<T>() => KtList<T>.of());
@@ -68,6 +72,12 @@ void testEmptyList(KtList<T> Function<T>() emptyList) {
       final empty = emptyList();
 
       expect(empty.isEmpty(), isTrue);
+    });
+
+    test("iterator have correct type", () {
+      final list = emptyList<Map<int, String>>();
+      expect(list.iterator().runtimeType.toString(),
+          contains("Map<int, String>>"));
     });
 
     test("throws when accessing an element", () {

--- a/test/collection/list_empty_test.dart
+++ b/test/collection/list_empty_test.dart
@@ -15,10 +15,6 @@ void main() {
   });
   group("KtList.empty", () {
     testEmptyList(<T>() => KtList<T>.empty());
-    test("const constructor", () {
-      const list = KtList<String>.empty();
-      expect(list.runtimeType.toString(), contains("<String>"));
-    });
   });
   group("KtList.of", () {
     testEmptyList(<T>() => KtList<T>.of());

--- a/test/collection/map_empty_test.dart
+++ b/test/collection/map_empty_test.dart
@@ -12,6 +12,10 @@ void main() {
   });
   group("KtMap.empty", () {
     testMap(<K, V>() => KtMap<K, V>.empty(), mutable: false);
+    test("const constructor", () {
+      const map = KtMap<int, String>.empty();
+      expect(map.runtimeType.toString(), contains("<int, String>"));
+    });
   });
   group("mutableMapFrom", () {
     testMap(<K, V>() => mutableMapFrom<K, V>());
@@ -58,6 +62,12 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap, {bool mutable = true}) {
       expect(emptyMap<int, int>().containsValue(0), isFalse);
       expect(emptyMap<List, List>().containsKey([]), isFalse);
       expect(emptyMap<List, List>().containsValue([]), isFalse);
+    });
+
+    test("entries have correct type", () {
+      final map = emptyMap<int, List<String>>();
+      expect(
+          map.entries.runtimeType.toString(), contains("<int, List<String>>"));
     });
 
     test("values iterator has no next", () {

--- a/test/collection/map_empty_test.dart
+++ b/test/collection/map_empty_test.dart
@@ -12,10 +12,6 @@ void main() {
   });
   group("KtMap.empty", () {
     testMap(<K, V>() => KtMap<K, V>.empty(), mutable: false);
-    test("const constructor", () {
-      const map = KtMap<int, String>.empty();
-      expect(map.runtimeType.toString(), contains("<int, String>"));
-    });
   });
   group("mutableMapFrom", () {
     testMap(<K, V>() => mutableMapFrom<K, V>());

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -663,7 +663,7 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap,
         2: "Ivysaur",
       });
       final copy = map.toList();
-      expect(copy, listOf(KtPair(1, "Bulbasaur"), KtPair(2, "Ivysaur")));
+      expect(copy, listOf(const KtPair(1, "Bulbasaur"), const KtPair(2, "Ivysaur")));
     });
   });
 

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -663,7 +663,8 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap,
         2: "Ivysaur",
       });
       final copy = map.toList();
-      expect(copy, listOf(const KtPair(1, "Bulbasaur"), const KtPair(2, "Ivysaur")));
+      expect(copy,
+          listOf(const KtPair(1, "Bulbasaur"), const KtPair(2, "Ivysaur")));
     });
   });
 

--- a/test/collection/map_mutable_extensions_test.dart
+++ b/test/collection/map_mutable_extensions_test.dart
@@ -274,7 +274,7 @@ void testMutableMap(KtMutableMap<K, V> Function<K, V>() emptyMap,
         1: "Bulbasaur",
         2: "Ivysaur",
       });
-      pokemon.putAllPairs(listFrom([
+      pokemon.putAllPairs(listFrom(const [
         KtPair(2, "Dito"),
         KtPair(3, "Venusaur"),
         KtPair(4, "Charmander"),
@@ -290,7 +290,7 @@ void testMutableMap(KtMutableMap<K, V> Function<K, V>() emptyMap,
         1: "Bulbasaur",
         2: "Ivysaur",
       });
-      pokemon.putAllPairs(listFrom([
+      pokemon.putAllPairs(listFrom(const [
         KtPair(2, "Dito"),
       ]));
       expect(pokemon.size, 2);
@@ -298,7 +298,7 @@ void testMutableMap(KtMutableMap<K, V> Function<K, V>() emptyMap,
     });
 
     test("putAllPairs doens't allow null as argument", () {
-      final pokemon = mutableMapFrom({
+      final pokemon = mutableMapFrom(const {
         1: "Bulbasaur",
         2: "Ivysaur",
       });

--- a/test/collection/map_mutable_test.dart
+++ b/test/collection/map_mutable_test.dart
@@ -65,7 +65,7 @@ void testMutableMap(
         2: "Ivysaur",
       });
       expect(pokemon.entries.map((it) => it.toPair()),
-          listOf(KtPair(1, "Bulbasaur"), KtPair(2, "Ivysaur")));
+          listOf(const KtPair(1, "Bulbasaur"), const KtPair(2, "Ivysaur")));
     });
 
     test("set value for mutable entry", () {

--- a/test/collection/map_test.dart
+++ b/test/collection/map_test.dart
@@ -42,7 +42,7 @@ void testMap(KtMap<K, V> Function<K, V>(Map<K, V> map) mapFrom,
 
     test("entry converts to KtPair", () {
       final pair = mapFrom({"a": 1}).entries.first().toPair();
-      expect(pair, KtPair("a", 1));
+      expect(pair, const KtPair("a", 1));
     });
   });
 

--- a/test/collection/set_empty_test.dart
+++ b/test/collection/set_empty_test.dart
@@ -9,10 +9,6 @@ void main() {
   });
   group("KtSet.empty", () {
     testEmptySet(<T>() => KtSet<T>.empty());
-    test("const constructor", () {
-      const set = KtSet<String>.empty();
-      expect(set.runtimeType.toString(), contains("<String>"));
-    });
   });
   group("KtSet.of", () {
     testEmptySet(<T>() => KtSet<T>.of());

--- a/test/collection/set_empty_test.dart
+++ b/test/collection/set_empty_test.dart
@@ -9,6 +9,10 @@ void main() {
   });
   group("KtSet.empty", () {
     testEmptySet(<T>() => KtSet<T>.empty());
+    test("const constructor", () {
+      const set = KtSet<String>.empty();
+      expect(set.runtimeType.toString(), contains("<String>"));
+    });
   });
   group("KtSet.of", () {
     testEmptySet(<T>() => KtSet<T>.of());
@@ -58,6 +62,12 @@ void testEmptySet(KtSet<T> Function<T>() emptySet, {bool mutable = false}) {
       expect(set.contains("c"), isFalse);
       expect(set.contains(null), isFalse);
       expect(set.contains(""), isFalse);
+    });
+
+    test("iterator have correct type", () {
+      final set = emptySet<Map<int, String>>();
+      expect(
+          set.iterator().runtimeType.toString(), contains("Map<int, String>>"));
     });
 
     test("is empty", () {

--- a/test/collection/tuples_test.dart
+++ b/test/collection/tuples_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: prefer_const_constructors
 import "package:kt_dart/collection.dart";
 import "package:test/test.dart";
 
@@ -10,7 +11,11 @@ void main() {
     });
 
     test("equals based on items", () {
-      expect(KtPair("a", "b"), KtPair("a", "b"));
+      final p1 = KtPair("a", "b");
+      final p2 = KtPair("a", "b");
+      expect(identical(p1, p2), isFalse);
+      expect(p1, p2);
+
       expect(KtPair("a", "b").hashCode, KtPair("a", "b").hashCode);
       expect(KtPair("a", "b"), isNot(equals(KtPair("a", "c"))));
       expect(

--- a/test/collection/tuples_test.dart
+++ b/test/collection/tuples_test.dart
@@ -4,6 +4,12 @@ import "package:test/test.dart";
 
 void main() {
   group("KtPair", () {
+    test("can be const", () {
+      const a = KtPair("a", "b");
+      const b = KtPair("a", "b");
+      expect(identical(a, b), isTrue);
+    });
+
     test("returns values put inside", () {
       final pair = KtPair("a", "b");
       expect(pair.first, "a");
@@ -40,6 +46,12 @@ void main() {
       expect(pair.first, "a");
       expect(pair.second, "b");
       expect(pair.third, "c");
+    });
+
+    test("can be const", () {
+      const a = KtTriple("a", "b", "c");
+      const b = KtTriple("a", "b", "c");
+      expect(identical(a, b), isTrue);
     });
 
     test("equals based on items", () {

--- a/test/exception/exceptions_test.dart
+++ b/test/exception/exceptions_test.dart
@@ -4,24 +4,24 @@ import "package:test/test.dart";
 void main() {
   group("IndexOutOfBoundsException", () {
     test("toString with message", () {
-      final e = IndexOutOfBoundsException("orange juice");
+      const e = IndexOutOfBoundsException("orange juice");
       expect(e.toString(), "IndexOutOfBoundsException: orange juice");
     });
 
     test("toString without message", () {
-      final e = IndexOutOfBoundsException();
+      const e = IndexOutOfBoundsException();
       expect(e.toString(), "IndexOutOfBoundsException");
     });
   });
 
   group("NoSuchElementException", () {
     test("toString with message", () {
-      final e = NoSuchElementException("orange juice");
+      const e = NoSuchElementException("orange juice");
       expect(e.toString(), "NoSuchElementException: orange juice");
     });
 
     test("toString without message", () {
-      final e = NoSuchElementException();
+      const e = NoSuchElementException();
       expect(e.toString(), "NoSuchElementException");
     });
   });


### PR DESCRIPTION
Use `const` where possible internally as well as for classes. New const constructors:

```dart
const KtPair("one", "two");
const KtTriple("one", "two", "three");
const IndexOutOfBoundsException("that was too far");
const NoSuchElementException("upsi");
```

Renamed `KCollectionExtension` to `KtCollectionExtension`


```
// Those const constructors aren't possible in dart 2.0 and dart 2.1, therefore not merged
const KtList.empty();
const KtSet.empty();
const KtMap.empty();
```
