### PR TITLE
Allow code coverage with dart 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ script:
   - dartanalyzer --fatal-infos --fatal-warnings ./
   - pub run test test/kt_dart_test.dart
   - pub publish -n
-  # run coverage with dart 2.2.0 only, it's broken on later versions https://github.com/dart-lang/coverage/issues/249
-  - if $(pub --version | grep -q '2.2.0'); then ./tool/run_coverage_locally.sh; fi
+  - ./tool/run_coverage_locally.sh
 after_success:
-  # run coverage report only on dart 2.2.0
-  - if $(pub --version | grep -q '2.2.0'); then bash <(curl -s https://codecov.io/bash); fi
+  # report code coverage only on a single node of the matrix. (prefer latest)
+  - if $(pub --version | grep -q '2.4.0'); then bash <(curl -s https://codecov.io/bash); fi

--- a/tool/run_coverage_locally.sh
+++ b/tool/run_coverage_locally.sh
@@ -4,12 +4,31 @@
   # install coverage when not found
   pub global activate coverage
 }
-pub global run coverage:collect_coverage --port=8111 -o out/coverage/coverage.json --resume-isolates --wait-paused &
-dart --observe=8111 --enable-asserts test/kt_dart_test.dart
-pub global run coverage:format_coverage --packages=.packages --report-on lib --in out/coverage/coverage.json --out out/coverage/lcov.info --lcov
+
+pub global run coverage:collect_coverage \
+    --port=8111 \
+    --out=out/coverage/coverage.json \
+    --wait-paused \
+    --resume-isolates \
+    &
+
+dart \
+    --disable-service-auth-codes \
+    --enable-vm-service=8111 \
+    --pause-isolates-on-exit  \
+    --enable-asserts \
+    test/kt_dart_test.dart
+
+pub global run coverage:format_coverage \
+    --lcov \
+    --in=out/coverage/coverage.json \
+    --out=out/coverage/lcov.info \
+    --packages=.packages \
+    --report-on lib
 
 if type genhtml >/dev/null 2>&1; then
- genhtml -o out/coverage/html out/coverage/lcov.info echo "open coverage report $PWD/out/coverage/html/index.html"
+ genhtml -o out/coverage/html out/coverage/lcov.info
+ echo "open coverage report $PWD/out/coverage/html/index.html"
 else
  echo "genhtml not installed, can't generate html coverage output"
 fi


### PR DESCRIPTION
Use new `--disable-service-auth-codes` flag to prevent hanging mentioned at https://github.com/dart-lang/coverage/issues/249

This change raises the minimum dart version to 2.3 to run coverage (with this script). Earlier versions don't know the flag and error.
