### PR TITLE
Remove lastIndex implementation from interface

### DIFF
--- a/lib/src/collection/kt_list.dart
+++ b/lib/src/collection/kt_list.dart
@@ -48,7 +48,7 @@ abstract class KtList<T> implements KtCollection<T>, KtListExtension<T> {
   int get size;
 
   /// Returns the index of the last item in the list or -1 if the list is empty.
-  int get lastIndex => size - 1;
+  int get lastIndex;
 
   /// Returns a read-only dart:core [List]
   ///

--- a/test/collection/list_test.dart
+++ b/test/collection/list_test.dart
@@ -400,5 +400,17 @@ void testList(
         expect(e.message, contains("unmodifiable"));
       });
     }
+
+    group("lastIndex", () {
+      test("lastIndex for an empty list is -1", () {
+        final list = emptyList();
+        expect(list.lastIndex, -1);
+      });
+
+      test("lastIndex for 3 items is 2", () {
+        final list = listOf("a", "b", "c");
+        expect(list.lastIndex, 2);
+      });
+    });
   });
 }


### PR DESCRIPTION
The abstract class never gets extended only implemented. A default interface implementation isn't helpful