### PR TITLE
[interopt] Add .dart property to convert to dart collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.7.0-dev.2
+
+New `.dart` extensions to convert KtDart collections back to dart collections.
+
+```dart
+  // New: Converting dart collections to KtDart collections (mutable views)
+  final KtMutableList<String> ktList = ["hey"].kt;
+  final KtMutableSet<String> ktSet = {"hey"}.kt;
+  final KtMutableMap<String, int> ktMap = {"hey": 1}.kt;
+
+  // Converting KtDart collections to dart collections
+  final List<String> dartList = KtList.of("hey").dart;
+  final Set<String> dartSet = KtSet.of("hey").dart;
+  final Map<String, int> dartMap = KtMap.from({"hey": 1}).dart;
+```
+
 ## 0.7.0-dev.1
 
 **KtDart makes full use of darts static extension methods, introduced with Dart 2.6.**
@@ -9,20 +25,20 @@ The public API stays unchanged and is backwards compatible.
 It is now easier then ever to convert dart to ktdart collections and vice versa. Use the `.kt` property to convert dart collections to KtDart collections. (Note: `.kt` create a view, which allows you to mutate the original dart collection).
  
 ```dart
-// New: Make dart collections immutable
-final KtList<String> = ["hey"].immutable();
-final KtSet<String> = {"hey"}.immutable();
-final KtMap<String, int> = {"hey": 1}.immutable();
+  // New: Make dart collections immutable
+  final KtList<String> list = ["hey"].immutable();
+  final KtSet<String> set = {"hey"}.immutable();
+  final KtMap<String, int> map = {"hey": 1}.immutable();
 
-// New: Converting dart collections to KtDart collections (mutable views)
-final KtMutableList<String> = ["hey"].kt;
-final KtMutableSet<String> = {"hey"}.kt;
-final KtMutableMap<String, int> = {"hey": 1}.kt;
+  // New: Converting dart collections to KtDart collections (mutable views)
+  final KtMutableList<String> ktList = ["hey"].kt;
+  final KtMutableSet<String> ktSet = {"hey"}.kt;
+  final KtMutableMap<String, int> ktMap = {"hey": 1}.kt;
 
-// Converting KtDart collections to dart collections
-final List<String> = KtList.of("hey").asList();
-final Set<String> = KtSet.of("hey").asSet();
-final Map<String> = KtMap.form({"hey": 1}).asMap();
+  // Converting KtDart collections to dart collections
+  final List<String> dartList = KtList.of("hey").asList();
+  final Set<String> dartSet = KtSet.of("hey").asSet();
+  final Map<String, int> dartMap = KtMap.from({"hey": 1}).asMap();
 ```
 
 # Tuple improvements

--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -17,7 +17,7 @@ abstract class KtIterable<T> {
 
 extension KtComparableIterableExtension<T extends Comparable<T>>
     on KtIterable<T> {
-  /// Returns a  art:core [Iterable]
+  /// Returns a dart:core [Iterable]
   ///
   /// This method can be used to interop between the dart:collection and the
   /// kt.dart world.

--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -17,6 +17,12 @@ abstract class KtIterable<T> {
 
 extension KtComparableIterableExtension<T extends Comparable<T>>
     on KtIterable<T> {
+  /// Returns a  art:core [Iterable]
+  ///
+  /// This method can be used to interop between the dart:collection and the
+  /// kt.dart world.
+  Iterable<T> get dart => iter;
+
   /// Returns the largest element or `null` if there are no elements.
   @nullable
   T max() {

--- a/lib/src/collection/kt_list.dart
+++ b/lib/src/collection/kt_list.dart
@@ -100,6 +100,12 @@ abstract class KtList<T> implements KtCollection<T> {
 }
 
 extension KtListExtensions<T> on KtList<T> {
+  /// Returns a read-only dart:core [List]
+  ///
+  /// This method can be used to interop between the dart:collection and the
+  /// kt.dart world.
+  List<T> get dart => asList();
+
   /// Returns a list containing all elements except last [n] elements.
   KtList<T> dropLast(int n) {
     assert(() {

--- a/lib/src/collection/kt_list_mutable.dart
+++ b/lib/src/collection/kt_list_mutable.dart
@@ -107,6 +107,15 @@ abstract class KtMutableList<T> implements KtList<T>, KtMutableCollection<T> {
 }
 
 extension KtMutableListExtensions<T> on KtMutableList<T> {
+  /// Creates a [List] instance that wraps the original [KtList]. It acts as a view.
+  ///
+  /// Mutations on the returned [List] are reflected on the original [KtList]
+  /// and vice versa.
+  ///
+  /// This method can be used to interop between the dart:collection and the
+  /// kt.dart world.
+  List<T> get dart => asList();
+
   /// Fills the list with the provided [value].
   ///
   /// Each element in the list gets replaced with the [value].

--- a/lib/src/collection/kt_map.dart
+++ b/lib/src/collection/kt_map.dart
@@ -85,6 +85,12 @@ abstract class KtMapEntry<K, V> {
 }
 
 extension KtMapExtensions<K, V> on KtMap<K, V> {
+  /// Returns a read-only dart:core [Map]
+  ///
+  /// This method can be used to interop between the dart:collection and the
+  /// kt.dart world.
+  Map<K, V> get dart => asMap();
+
   /// Returns true if all entries match the given [predicate].
   /// [predicate] must not be null.
   bool all(Function(K key, V value) predicate) {

--- a/lib/src/collection/kt_map_mutable.dart
+++ b/lib/src/collection/kt_map_mutable.dart
@@ -82,6 +82,15 @@ abstract class KtMutableMapEntry<K, V> extends KtMapEntry<K, V> {
 }
 
 extension KtMutableMapExtensions<K, V> on KtMutableMap<K, V> {
+  /// Creates a [Map] instance that wraps the original [KtMap]. It acts as a view.
+  ///
+  /// Mutations on the returned [Map] are reflected on the original [KtMap]
+  /// and vice versa.
+  ///
+  /// This method can be used to interop between the dart:collection and the
+  /// kt.dart world.
+  Map<K, V> get dart => asMap();
+
   /// Returns the value for the given key. If the key is not found in the map, calls the [defaultValue] function,
   /// puts its result into the map under the given key and returns it.
   ///

--- a/lib/src/collection/kt_set.dart
+++ b/lib/src/collection/kt_set.dart
@@ -71,6 +71,14 @@ abstract class KtSet<T> implements KtCollection<T> {
   KtIterator<T> iterator();
 }
 
+extension KtSetExtension<T> on KtSet<T> {
+  /// Returns a read-only dart:core [Set]
+  ///
+  /// This method can be used to interop between the dart:collection and the
+  /// kt.dart world.
+  Set<T> get dart => asSet();
+}
+
 extension NullableKtSetExtensions<T> on KtSet<T> /*?*/ {
   /// Returns this [KtSet] if it's not `null` and the empty set otherwise.
   KtSet<T> orEmpty() => this ?? KtSet<T>.empty();

--- a/lib/src/collection/kt_set_mutable.dart
+++ b/lib/src/collection/kt_set_mutable.dart
@@ -69,3 +69,14 @@ abstract class KtMutableSet<T> implements KtSet<T>, KtMutableCollection<T> {
   @override
   void clear();
 }
+
+extension KtMutableSetExtension<T> on KtMutableSet<T> {
+  /// Creates a [Set] instance that wraps the original [KtSet]. It acts as a view.
+  ///
+  /// Mutations on the returned [Set] are reflected on the original [KtSet]
+  /// and vice versa.
+  ///
+  /// This method can be used to interop between the dart:collection and the
+  /// kt.dart world.
+  Set<T> get dart => asSet();
+}

--- a/test/collection/collection_mutable_test.dart
+++ b/test/collection/collection_mutable_test.dart
@@ -4,31 +4,33 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mutableList", () {
-    testCollection(<T>() => mutableListOf<T>(),
-        <T>(Iterable<T> iterable) => mutableListFrom(iterable));
-  });
-  group("KtMutableList", () {
-    testCollection(<T>() => KtMutableList<T>.empty(),
-        <T>(Iterable<T> iterable) => KtMutableList.from(iterable));
-  });
-  group("hashset", () {
-    testCollection(<T>() => hashSetOf<T>(),
-        <T>(Iterable<T> iterable) => hashSetFrom(iterable),
-        ordered: false);
-  });
-  group("KHashSet", () {
-    testCollection(<T>() => KtHashSet<T>.empty(),
-        <T>(Iterable<T> iterable) => KtHashSet.from(iterable),
-        ordered: false);
-  });
-  group("linkedSet", () {
-    testCollection(<T>() => linkedSetOf<T>(),
-        <T>(Iterable<T> iterable) => linkedSetFrom(iterable));
-  });
-  group("KLinkedSet", () {
-    testCollection(<T>() => KtLinkedSet<T>.empty(),
-        <T>(Iterable<T> iterable) => KtLinkedSet.from(iterable));
+  group("KtMutableCollection", () {
+    group("mutableList", () {
+      testCollection(<T>() => mutableListOf<T>(),
+          <T>(Iterable<T> iterable) => mutableListFrom(iterable));
+    });
+    group("KtMutableList", () {
+      testCollection(<T>() => KtMutableList<T>.empty(),
+          <T>(Iterable<T> iterable) => KtMutableList.from(iterable));
+    });
+    group("hashset", () {
+      testCollection(<T>() => hashSetOf<T>(),
+          <T>(Iterable<T> iterable) => hashSetFrom(iterable),
+          ordered: false);
+    });
+    group("KHashSet", () {
+      testCollection(<T>() => KtHashSet<T>.empty(),
+          <T>(Iterable<T> iterable) => KtHashSet.from(iterable),
+          ordered: false);
+    });
+    group("linkedSet", () {
+      testCollection(<T>() => linkedSetOf<T>(),
+          <T>(Iterable<T> iterable) => linkedSetFrom(iterable));
+    });
+    group("KLinkedSet", () {
+      testCollection(<T>() => KtLinkedSet<T>.empty(),
+          <T>(Iterable<T> iterable) => KtLinkedSet.from(iterable));
+    });
   });
 }
 

--- a/test/collection/collection_test.dart
+++ b/test/collection/collection_test.dart
@@ -6,47 +6,49 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("list", () {
-    testCollection(<T>() => emptyList<T>(),
-        <T>(Iterable<T> iterable) => listFrom(iterable));
-  });
-  group("KtList", () {
-    testCollection(<T>() => KtList<T>.empty(),
-        <T>(Iterable<T> iterable) => KtList.from(iterable));
-  });
-  group("mutableList", () {
-    testCollection(<T>() => mutableListOf<T>(),
-        <T>(Iterable<T> iterable) => mutableListFrom(iterable));
-  });
-  group("KtMutableList", () {
-    testCollection(<T>() => KtMutableList<T>.empty(),
-        <T>(Iterable<T> iterable) => KtMutableList.from(iterable));
-  });
-  group("set", () {
-    testCollection(
-        <T>() => emptySet<T>(), <T>(Iterable<T> iterable) => setFrom(iterable));
-  });
-  group("KtSet", () {
-    testCollection(<T>() => KtSet<T>.empty(),
-        <T>(Iterable<T> iterable) => KtSet.from(iterable));
-  });
-  group("hashset", () {
-    testCollection(<T>() => hashSetOf<T>(),
-        <T>(Iterable<T> iterable) => hashSetFrom(iterable),
-        ordered: false);
-  });
-  group("KHashSet", () {
-    testCollection(<T>() => KtHashSet<T>.empty(),
-        <T>(Iterable<T> iterable) => KtHashSet.from(iterable),
-        ordered: false);
-  });
-  group("linkedSet", () {
-    testCollection(<T>() => linkedSetOf<T>(),
-        <T>(Iterable<T> iterable) => linkedSetFrom(iterable));
-  });
-  group("KLinkedSet", () {
-    testCollection(<T>() => KtLinkedSet<T>.empty(),
-        <T>(Iterable<T> iterable) => KtLinkedSet.from(iterable));
+  group("KtCollection", () {
+    group("list", () {
+      testCollection(<T>() => emptyList<T>(),
+          <T>(Iterable<T> iterable) => listFrom(iterable));
+    });
+    group("KtList", () {
+      testCollection(<T>() => KtList<T>.empty(),
+          <T>(Iterable<T> iterable) => KtList.from(iterable));
+    });
+    group("mutableList", () {
+      testCollection(<T>() => mutableListOf<T>(),
+          <T>(Iterable<T> iterable) => mutableListFrom(iterable));
+    });
+    group("KtMutableList", () {
+      testCollection(<T>() => KtMutableList<T>.empty(),
+          <T>(Iterable<T> iterable) => KtMutableList.from(iterable));
+    });
+    group("set", () {
+      testCollection(<T>() => emptySet<T>(),
+          <T>(Iterable<T> iterable) => setFrom(iterable));
+    });
+    group("KtSet", () {
+      testCollection(<T>() => KtSet<T>.empty(),
+          <T>(Iterable<T> iterable) => KtSet.from(iterable));
+    });
+    group("hashset", () {
+      testCollection(<T>() => hashSetOf<T>(),
+          <T>(Iterable<T> iterable) => hashSetFrom(iterable),
+          ordered: false);
+    });
+    group("KHashSet", () {
+      testCollection(<T>() => KtHashSet<T>.empty(),
+          <T>(Iterable<T> iterable) => KtHashSet.from(iterable),
+          ordered: false);
+    });
+    group("linkedSet", () {
+      testCollection(<T>() => linkedSetOf<T>(),
+          <T>(Iterable<T> iterable) => linkedSetFrom(iterable));
+    });
+    group("KLinkedSet", () {
+      testCollection(<T>() => KtLinkedSet<T>.empty(),
+          <T>(Iterable<T> iterable) => KtLinkedSet.from(iterable));
+    });
   });
 }
 

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -5,52 +5,54 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("iterable", () {
-    // TODO replace with Iterable.generate once implemented
-    testIterable(<T>() => EmptyIterable<T>(),
-        <T>(Iterable<T> iterable) => DartIterable(iterable));
-  });
-  group("list", () {
-    testIterable(<T>() => emptyList<T>(),
-        <T>(Iterable<T> iterable) => listFrom(iterable));
-  });
-  group("KtList", () {
-    testIterable(<T>() => KtList<T>.empty(),
-        <T>(Iterable<T> iterable) => KtList<T>.from(iterable));
-  });
-  group("mutableList", () {
-    testIterable(<T>() => emptyList<T>(),
-        <T>(Iterable<T> iterable) => mutableListFrom(iterable));
-  });
-  group("KtMutableList", () {
-    testIterable(<T>() => KtMutableList<T>.empty(),
-        <T>(Iterable<T> iterable) => KtMutableList<T>.from(iterable));
-  });
-  group("set", () {
-    testIterable(
-        <T>() => emptySet<T>(), <T>(Iterable<T> iterable) => setFrom(iterable));
-  });
-  group("KtSet", () {
-    testIterable(<T>() => KtSet<T>.empty(),
-        <T>(Iterable<T> iterable) => KtSet<T>.from(iterable));
-  });
-  group("hashset", () {
-    testIterable(<T>() => emptySet<T>(),
-        <T>(Iterable<T> iterable) => hashSetFrom(iterable),
-        ordered: false);
-  });
-  group("KHashSet", () {
-    testIterable(<T>() => KtHashSet<T>.empty(),
-        <T>(Iterable<T> iterable) => KtHashSet<T>.from(iterable),
-        ordered: false);
-  });
-  group("linkedSet", () {
-    testIterable(<T>() => linkedSetOf<T>(),
-        <T>(Iterable<T> iterable) => linkedSetFrom(iterable));
-  });
-  group("KLinkedSet", () {
-    testIterable(<T>() => KtLinkedSet<T>.empty(),
-        <T>(Iterable<T> iterable) => KtLinkedSet<T>.from(iterable));
+  group("KtIterableExtensions", () {
+    group("iterable", () {
+      // TODO replace with Iterable.generate once implemented
+      testIterable(<T>() => EmptyIterable<T>(),
+          <T>(Iterable<T> iterable) => DartIterable(iterable));
+    });
+    group("list", () {
+      testIterable(<T>() => emptyList<T>(),
+          <T>(Iterable<T> iterable) => listFrom(iterable));
+    });
+    group("KtList", () {
+      testIterable(<T>() => KtList<T>.empty(),
+          <T>(Iterable<T> iterable) => KtList<T>.from(iterable));
+    });
+    group("mutableList", () {
+      testIterable(<T>() => emptyList<T>(),
+          <T>(Iterable<T> iterable) => mutableListFrom(iterable));
+    });
+    group("KtMutableList", () {
+      testIterable(<T>() => KtMutableList<T>.empty(),
+          <T>(Iterable<T> iterable) => KtMutableList<T>.from(iterable));
+    });
+    group("set", () {
+      testIterable(<T>() => emptySet<T>(),
+          <T>(Iterable<T> iterable) => setFrom(iterable));
+    });
+    group("KtSet", () {
+      testIterable(<T>() => KtSet<T>.empty(),
+          <T>(Iterable<T> iterable) => KtSet<T>.from(iterable));
+    });
+    group("hashset", () {
+      testIterable(<T>() => emptySet<T>(),
+          <T>(Iterable<T> iterable) => hashSetFrom(iterable),
+          ordered: false);
+    });
+    group("KHashSet", () {
+      testIterable(<T>() => KtHashSet<T>.empty(),
+          <T>(Iterable<T> iterable) => KtHashSet<T>.from(iterable),
+          ordered: false);
+    });
+    group("linkedSet", () {
+      testIterable(<T>() => linkedSetOf<T>(),
+          <T>(Iterable<T> iterable) => linkedSetFrom(iterable));
+    });
+    group("KLinkedSet", () {
+      testIterable(<T>() => KtLinkedSet<T>.empty(),
+          <T>(Iterable<T> iterable) => KtLinkedSet<T>.from(iterable));
+    });
   });
 }
 

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -343,6 +343,22 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("dart property", () {
+    test("dart property returns a dart iterable", () {
+      final Iterable<String> iterable = iterableOf(["a", "b", "c"]).dart;
+      if (ordered) {
+        expect(iterable.first, "a");
+        expect(iterable.skip(1).first, "b");
+        expect(iterable.skip(2).first, "c");
+      }
+      expect(iterable.length, 3);
+    });
+    test("dart property returns empty as original", () {
+      final Iterable<String> iterable = emptyIterable<String>().dart;
+      expect(iterable.length, 0);
+    });
+  });
+
   group("drop", () {
     if (ordered) {
       test("drop first value ordered", () {

--- a/test/collection/iterable_mutable_extensions_test.dart
+++ b/test/collection/iterable_mutable_extensions_test.dart
@@ -5,38 +5,40 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mutableIterable", () {
-    testIterable(<T>() => DartMutableIterable<T>([]),
-        <T>(Iterable<T> iterable) => DartMutableIterable(iterable));
-  });
-  group("mutableList", () {
-    testIterable(<T>() => mutableListOf<T>(),
-        <T>(Iterable<T> iterable) => mutableListFrom(iterable));
-  });
+  group("KtMutableIterableExtensions", () {
+    group("mutableIterable", () {
+      testIterable(<T>() => DartMutableIterable<T>([]),
+          <T>(Iterable<T> iterable) => DartMutableIterable(iterable));
+    });
+    group("mutableList", () {
+      testIterable(<T>() => mutableListOf<T>(),
+          <T>(Iterable<T> iterable) => mutableListFrom(iterable));
+    });
 
-  group("hashset", () {
-    testIterable(<T>() => hashSetOf<T>(),
-        <T>(Iterable<T> iterable) => hashSetFrom(iterable),
-        ordered: false);
-  });
-  group("KHashSet", () {
-    testIterable(<T>() => KtHashSet<T>.of(),
-        <T>(Iterable<T> iterable) => KtHashSet<T>.from(iterable));
-  });
+    group("hashset", () {
+      testIterable(<T>() => hashSetOf<T>(),
+          <T>(Iterable<T> iterable) => hashSetFrom(iterable),
+          ordered: false);
+    });
+    group("KtHashSet", () {
+      testIterable(<T>() => KtHashSet<T>.of(),
+          <T>(Iterable<T> iterable) => KtHashSet<T>.from(iterable));
+    });
 
-  group("linkedSet", () {
-    testIterable(<T>() => linkedSetOf<T>(),
-        <T>(Iterable<T> iterable) => linkedSetFrom(iterable));
-  });
-  group("KHashSet", () {
-    testIterable(<T>() => KtLinkedSet<T>.of(),
-        <T>(Iterable<T> iterable) => KtLinkedSet<T>.from(iterable));
-  });
+    group("linkedSet", () {
+      testIterable(<T>() => linkedSetOf<T>(),
+          <T>(Iterable<T> iterable) => linkedSetFrom(iterable));
+    });
+    group("KtHashSet", () {
+      testIterable(<T>() => KtLinkedSet<T>.of(),
+          <T>(Iterable<T> iterable) => KtLinkedSet<T>.from(iterable));
+    });
 
-  test("DartMutableIterable exposes dart Iterable via iter", () {
-    final dartIterable = [];
-    final exposedIter = DartMutableIterable(dartIterable).iter;
-    expect(identical(dartIterable, exposedIter), isTrue);
+    test("DartMutableIterable exposes dart Iterable via iter", () {
+      final dartIterable = [];
+      final exposedIter = DartMutableIterable(dartIterable).iter;
+      expect(identical(dartIterable, exposedIter), isTrue);
+    });
   });
 }
 

--- a/test/collection/list_empty_test.dart
+++ b/test/collection/list_empty_test.dart
@@ -22,9 +22,6 @@ void main() {
   group("KtList.of", () {
     testEmptyList(<T>() => KtList<T>.from(), mutable: false);
   });
-  group("mutableList", () {
-    testEmptyList(<T>() => emptyList<T>());
-  });
   group("mutableListOf", () {
     testEmptyList(<T>() => mutableListOf<T>());
   });
@@ -217,6 +214,15 @@ void testEmptyList(KtList<T> Function<T>() emptyList, {bool mutable = true}) {
         final dartList = emptyList<int>().list;
         final e = catchException<UnsupportedError>(() => dartList.add(1));
         expect(e.message, contains("unmodifiable"));
+      });
+    } else {
+      test("deprecated list property returns an modifiable list", () {
+        final original = emptyList<int>();
+        // ignore: deprecated_member_use_from_same_package
+        final dartList = original.list;
+        dartList.add(1);
+        expect(original, listOf(1));
+        expect(dartList, [1]);
       });
     }
   });

--- a/test/collection/list_empty_test.dart
+++ b/test/collection/list_empty_test.dart
@@ -4,38 +4,40 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("emptyList", () {
-    testEmptyList(<T>() => emptyList<T>(), mutable: false);
-  });
-  group("listOf", () {
-    testEmptyList(<T>() => listOf<T>(), mutable: false);
-  });
-  group("listFrom", () {
-    testEmptyList(<T>() => listFrom<T>(), mutable: false);
-  });
-  group("KtList.empty", () {
-    testEmptyList(<T>() => KtList<T>.empty(), mutable: false);
-  });
-  group("KtList.of", () {
-    testEmptyList(<T>() => KtList<T>.of(), mutable: false);
-  });
-  group("KtList.of", () {
-    testEmptyList(<T>() => KtList<T>.from(), mutable: false);
-  });
-  group("mutableListOf", () {
-    testEmptyList(<T>() => mutableListOf<T>());
-  });
-  group("mutableListFrom", () {
-    testEmptyList(<T>() => mutableListFrom<T>());
-  });
-  group("KtMutableList.empty", () {
-    testEmptyList(<T>() => KtMutableList<T>.empty());
-  });
-  group("KtMutableList.of", () {
-    testEmptyList(<T>() => KtMutableList<T>.of());
-  });
-  group("KtMutableList.from", () {
-    testEmptyList(<T>() => KtMutableList<T>.from());
+  group("EmptyList", () {
+    group("emptyList", () {
+      testEmptyList(<T>() => emptyList<T>(), mutable: false);
+    });
+    group("listOf", () {
+      testEmptyList(<T>() => listOf<T>(), mutable: false);
+    });
+    group("listFrom", () {
+      testEmptyList(<T>() => listFrom<T>(), mutable: false);
+    });
+    group("KtList.empty", () {
+      testEmptyList(<T>() => KtList<T>.empty(), mutable: false);
+    });
+    group("KtList.of", () {
+      testEmptyList(<T>() => KtList<T>.of(), mutable: false);
+    });
+    group("KtList.of", () {
+      testEmptyList(<T>() => KtList<T>.from(), mutable: false);
+    });
+    group("mutableListOf", () {
+      testEmptyList(<T>() => mutableListOf<T>());
+    });
+    group("mutableListFrom", () {
+      testEmptyList(<T>() => mutableListFrom<T>());
+    });
+    group("KtMutableList.empty", () {
+      testEmptyList(<T>() => KtMutableList<T>.empty());
+    });
+    group("KtMutableList.of", () {
+      testEmptyList(<T>() => KtMutableList<T>.of());
+    });
+    group("KtMutableList.from", () {
+      testEmptyList(<T>() => KtMutableList<T>.from());
+    });
   });
 }
 

--- a/test/collection/list_extensions_test.dart
+++ b/test/collection/list_extensions_test.dart
@@ -55,7 +55,8 @@ void main() {
                 T arg9]) =>
             mutableListOf(
                 arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable));
+        <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable),
+        mutable: true);
   });
   group("KtMutableList", () {
     testList(
@@ -73,26 +74,47 @@ void main() {
                 T arg9]) =>
             KtMutableList.of(
                 arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => KtMutableList.from(iterable));
+        <T>([Iterable<T> iterable = const []]) => KtMutableList.from(iterable),
+        mutable: true);
   });
 }
 
 void testList(
-    KtList<T> Function<T>() emptyList,
-    KtList<T> Function<T>(
-            [T arg0,
-            T arg1,
-            T arg2,
-            T arg3,
-            T arg4,
-            T arg5,
-            T arg6,
-            T arg7,
-            T arg8,
-            T arg9])
-        listOf,
-    KtList<T> Function<T>([Iterable<T> iterable]) listFrom,
-    {bool ordered = true}) {
+  KtList<T> Function<T>() emptyList,
+  KtList<T> Function<T>(
+          [T arg0,
+          T arg1,
+          T arg2,
+          T arg3,
+          T arg4,
+          T arg5,
+          T arg6,
+          T arg7,
+          T arg8,
+          T arg9])
+      listOf,
+  KtList<T> Function<T>([Iterable<T> iterable]) listFrom, {
+  bool ordered = true,
+  bool mutable = false,
+}) {
+  group("dart property", () {
+    if (mutable) {
+      test("dart property is mutating original collection", () {
+        final original = listFrom<String>(["a", "b", "c"]);
+        final dartList = original.dart;
+        dartList.add("x");
+        expect(dartList, ["a", "b", "c", "x"]);
+        expect(original, listOf("a", "b", "c", "x"));
+      });
+    } else {
+      test("dart property returns an unmodifiable list", () {
+        final dartList = listFrom<String>(["a", "b", "c"]).dart;
+        final e = catchException<UnsupportedError>(() => dartList.add("x"));
+        expect(e.message, contains("unmodifiable"));
+      });
+    }
+  });
+
   group("dropLast", () {
     test("drop last 3 items", () {
       final list = listOf(1, 2, 3, 4, 5, 6, 7);

--- a/test/collection/list_extensions_test.dart
+++ b/test/collection/list_extensions_test.dart
@@ -4,78 +4,82 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("list", () {
-    testList(
-        <T>() => emptyList<T>(),
-        <T>(
-                [T arg0,
-                T arg1,
-                T arg2,
-                T arg3,
-                T arg4,
-                T arg5,
-                T arg6,
-                T arg7,
-                T arg8,
-                T arg9]) =>
-            listOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => listFrom(iterable));
-  });
-  group("KtList", () {
-    testList(
-        <T>() => KtList<T>.empty(),
-        <T>(
-                [T arg0,
-                T arg1,
-                T arg2,
-                T arg3,
-                T arg4,
-                T arg5,
-                T arg6,
-                T arg7,
-                T arg8,
-                T arg9]) =>
-            KtList.of(
-                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => KtList.from(iterable));
-  });
-  group("mutableList", () {
-    testList(
-        <T>() => mutableListOf<T>(),
-        <T>(
-                [T arg0,
-                T arg1,
-                T arg2,
-                T arg3,
-                T arg4,
-                T arg5,
-                T arg6,
-                T arg7,
-                T arg8,
-                T arg9]) =>
-            mutableListOf(
-                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable),
-        mutable: true);
-  });
-  group("KtMutableList", () {
-    testList(
-        <T>() => KtMutableList<T>.empty(),
-        <T>(
-                [T arg0,
-                T arg1,
-                T arg2,
-                T arg3,
-                T arg4,
-                T arg5,
-                T arg6,
-                T arg7,
-                T arg8,
-                T arg9]) =>
-            KtMutableList.of(
-                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => KtMutableList.from(iterable),
-        mutable: true);
+  group("KtListExtensions", () {
+    group("list", () {
+      testList(
+          <T>() => emptyList<T>(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              listOf(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) => listFrom(iterable));
+    });
+    group("KtList", () {
+      testList(
+          <T>() => KtList<T>.empty(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              KtList.of(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) => KtList.from(iterable));
+    });
+    group("mutableList", () {
+      testList(
+          <T>() => mutableListOf<T>(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              mutableListOf(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable),
+          mutable: true);
+    });
+    group("KtMutableList", () {
+      testList(
+          <T>() => KtMutableList<T>.empty(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              KtMutableList.of(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) =>
+              KtMutableList.from(iterable),
+          mutable: true);
+    });
   });
 }
 

--- a/test/collection/list_mutable_extensions_test.dart
+++ b/test/collection/list_mutable_extensions_test.dart
@@ -6,41 +6,44 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mutableList", () {
-    testList(
-        <T>() => mutableListOf<T>(),
-        <T>(
-                [T arg0,
-                T arg1,
-                T arg2,
-                T arg3,
-                T arg4,
-                T arg5,
-                T arg6,
-                T arg7,
-                T arg8,
-                T arg9]) =>
-            mutableListOf(
-                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable));
-  });
-  group("KtMutableList", () {
-    testList(
-        <T>() => KtMutableList<T>.empty(),
-        <T>(
-                [T arg0,
-                T arg1,
-                T arg2,
-                T arg3,
-                T arg4,
-                T arg5,
-                T arg6,
-                T arg7,
-                T arg8,
-                T arg9]) =>
-            KtMutableList.of(
-                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => KtMutableList.from(iterable));
+  group("KtMutableListExtensions", () {
+    group("mutableList", () {
+      testList(
+          <T>() => mutableListOf<T>(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              mutableListOf(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable));
+    });
+    group("KtMutableList", () {
+      testList(
+          <T>() => KtMutableList<T>.empty(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              KtMutableList.of(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) =>
+              KtMutableList.from(iterable));
+    });
   });
 }
 

--- a/test/collection/list_mutable_extensions_test.dart
+++ b/test/collection/list_mutable_extensions_test.dart
@@ -78,6 +78,16 @@ void testList(
     });
   });
 
+  group("dart property", () {
+    test("dart property is mutating original collection", () {
+      final original = mutableListOf("a", "b", "c");
+      final dartList = original.dart;
+      dartList.add("x");
+      expect(dartList, ["a", "b", "c", "x"]);
+      expect(original, listOf("a", "b", "c", "x"));
+    });
+  });
+
   group("fill", () {
     test("replace all elements", () {
       final list = mutableListOf("a", "b", "c");

--- a/test/collection/list_mutable_test.dart
+++ b/test/collection/list_mutable_test.dart
@@ -4,41 +4,44 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mutableList", () {
-    testList(
-        <T>() => emptyList<T>(),
-        <T>(
-                [T arg0,
-                T arg1,
-                T arg2,
-                T arg3,
-                T arg4,
-                T arg5,
-                T arg6,
-                T arg7,
-                T arg8,
-                T arg9]) =>
-            mutableListOf(
-                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable));
-  });
   group("KtMutableList", () {
-    testList(
-        <T>() => KtMutableList<T>.empty(),
-        <T>(
-                [T arg0,
-                T arg1,
-                T arg2,
-                T arg3,
-                T arg4,
-                T arg5,
-                T arg6,
-                T arg7,
-                T arg8,
-                T arg9]) =>
-            KtMutableList.of(
-                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => KtMutableList.from(iterable));
+    group("mutableList", () {
+      testList(
+          <T>() => emptyList<T>(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              mutableListOf(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable));
+    });
+    group("KtMutableList", () {
+      testList(
+          <T>() => KtMutableList<T>.empty(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              KtMutableList.of(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) =>
+              KtMutableList.from(iterable));
+    });
   });
 }
 

--- a/test/collection/list_test.dart
+++ b/test/collection/list_test.dart
@@ -4,47 +4,10 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("list", () {
-    testList(
-      <T>() => emptyList<T>(),
-      <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          listOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>([Iterable<T> iterable = const []]) => listFrom(iterable),
-      mutable: false,
-    );
-  });
   group("KtList", () {
-    testList(
-      <T>() => KtList<T>.empty(),
-      <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          KtList.of(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>([Iterable<T> iterable = const []]) => KtList.from(iterable),
-      mutable: false,
-    );
-  });
-  group("mutableList", () {
-    testList(
-        <T>() => mutableListOf<T>(),
+    group("list", () {
+      testList(
+        <T>() => emptyList<T>(),
         <T>(
                 [T arg0,
                 T arg1,
@@ -56,13 +19,14 @@ void main() {
                 T arg7,
                 T arg8,
                 T arg9]) =>
-            mutableListOf(
-                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable));
-  });
-  group("KtMutableList", () {
-    testList(
-        <T>() => KtMutableList<T>.empty(),
+            listOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>([Iterable<T> iterable = const []]) => listFrom(iterable),
+        mutable: false,
+      );
+    });
+    group("KtList", () {
+      testList(
+        <T>() => KtList<T>.empty(),
         <T>(
                 [T arg0,
                 T arg1,
@@ -74,9 +38,49 @@ void main() {
                 T arg7,
                 T arg8,
                 T arg9]) =>
-            KtMutableList.of(
+            KtList.of(
                 arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-        <T>([Iterable<T> iterable = const []]) => KtMutableList.from(iterable));
+        <T>([Iterable<T> iterable = const []]) => KtList.from(iterable),
+        mutable: false,
+      );
+    });
+    group("mutableList", () {
+      testList(
+          <T>() => mutableListOf<T>(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              mutableListOf(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) => mutableListFrom(iterable));
+    });
+    group("KtMutableList", () {
+      testList(
+          <T>() => KtMutableList<T>.empty(),
+          <T>(
+                  [T arg0,
+                  T arg1,
+                  T arg2,
+                  T arg3,
+                  T arg4,
+                  T arg5,
+                  T arg6,
+                  T arg7,
+                  T arg8,
+                  T arg9]) =>
+              KtMutableList.of(
+                  arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+          <T>([Iterable<T> iterable = const []]) =>
+              KtMutableList.from(iterable));
+    });
   });
 }
 

--- a/test/collection/map_empty_test.dart
+++ b/test/collection/map_empty_test.dart
@@ -4,203 +4,202 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mapFrom", () {
-    testMap(<K, V>() => emptyMap<K, V>(), mutable: false);
-  });
-  group("KtMap.from", () {
-    testMap(<K, V>() => KtMap<K, V>.from(), mutable: false);
-  });
-  group("KtMap.empty", () {
-    testMap(<K, V>() => KtMap<K, V>.empty(), mutable: false);
-  });
-  group("mutableMapFrom", () {
-    testMap(<K, V>() => mutableMapFrom<K, V>());
-  });
-  group("KtMutableMap.empty", () {
-    testMap(<K, V>() => KtMutableMap<K, V>.empty());
-  });
-  group("KtMutableMap.from", () {
-    testMap(<K, V>() => KtMutableMap<K, V>.from());
-  });
-  group("hashMapFrom", () {
-    testMap(<K, V>() => hashMapFrom<K, V>());
-  });
-  group("KHashMap.empty", () {
-    testMap(<K, V>() => KtHashMap<K, V>.empty());
-  });
-  group("KHashMap.from", () {
-    testMap(<K, V>() => KtHashMap<K, V>.from());
-  });
-  group("linkedMapFrom", () {
-    testMap(<K, V>() => linkedMapFrom<K, V>());
-  });
-  group("KLinkedMap.empty", () {
-    testMap(<K, V>() => KtLinkedMap<K, V>.empty());
-  });
-  group("KLinkedMap.from", () {
-    testMap(<K, V>() => KtLinkedMap<K, V>.from());
+  group("EmptyMap", () {
+    group("mapFrom", () {
+      testMap(<K, V>() => emptyMap<K, V>(), mutable: false);
+    });
+    group("KtMap.from", () {
+      testMap(<K, V>() => KtMap<K, V>.from(), mutable: false);
+    });
+    group("KtMap.empty", () {
+      testMap(<K, V>() => KtMap<K, V>.empty(), mutable: false);
+    });
+    group("mutableMapFrom", () {
+      testMap(<K, V>() => mutableMapFrom<K, V>());
+    });
+    group("KtMutableMap.empty", () {
+      testMap(<K, V>() => KtMutableMap<K, V>.empty());
+    });
+    group("KtMutableMap.from", () {
+      testMap(<K, V>() => KtMutableMap<K, V>.from());
+    });
+    group("hashMapFrom", () {
+      testMap(<K, V>() => hashMapFrom<K, V>());
+    });
+    group("KtHashMap.empty", () {
+      testMap(<K, V>() => KtHashMap<K, V>.empty());
+    });
+    group("KtHashMap.from", () {
+      testMap(<K, V>() => KtHashMap<K, V>.from());
+    });
+    group("linkedMapFrom", () {
+      testMap(<K, V>() => linkedMapFrom<K, V>());
+    });
+    group("KtLinkedMap.empty", () {
+      testMap(<K, V>() => KtLinkedMap<K, V>.empty());
+    });
+    group("KtLinkedMap.from", () {
+      testMap(<K, V>() => KtLinkedMap<K, V>.from());
+    });
   });
 }
 
 void testMap(KtMap<K, V> Function<K, V>() emptyMap, {bool mutable = true}) {
-  group("empty map", () {
-    test("has no elements", () {
-      final empty = emptyMap<String, Object>();
-      expect(empty.size, equals(0));
+  test("has no elements", () {
+    final empty = emptyMap<String, Object>();
+    expect(empty.size, equals(0));
+  });
+
+  test("contains nothing", () {
+    expect(emptyMap<String, String>().containsKey("asdf"), isFalse);
+    expect(emptyMap<String, String>().containsValue("asdf"), isFalse);
+    expect(emptyMap<int, int>().containsKey(null), isFalse);
+    expect(emptyMap<int, int>().containsValue(null), isFalse);
+    expect(emptyMap<int, int>().containsKey(0), isFalse);
+    expect(emptyMap<int, int>().containsValue(0), isFalse);
+    expect(emptyMap<List, List>().containsKey([]), isFalse);
+    expect(emptyMap<List, List>().containsValue([]), isFalse);
+  });
+
+  test("entries have correct type", () {
+    final map = emptyMap<int, List<String>>();
+    expect(map.entries.runtimeType.toString(), contains("<int, List<String>>"));
+  });
+
+  test("values iterator has no next", () {
+    final empty = emptyMap();
+    expect(empty.values.iterator().hasNext(), isFalse);
+    expect(() => empty.values.iterator().next(),
+        throwsA(const TypeMatcher<NoSuchElementException>()));
+  });
+
+  test("keys iterator has no next", () {
+    final empty = emptyMap();
+    expect(empty.keys.iterator().hasNext(), isFalse);
+    expect(() => empty.keys.iterator().next(),
+        throwsA(const TypeMatcher<NoSuchElementException>()));
+  });
+
+  test("is empty", () {
+    final empty = emptyMap<String, Object>();
+
+    expect(empty.isEmpty(), isTrue);
+  });
+
+  test("get always returns null", () {
+    final empty = emptyMap();
+
+    expect(empty.get(0), isNull);
+    expect(empty.get(1), isNull);
+    expect(empty.get(-1), isNull);
+    expect(empty.get(null), isNull);
+  });
+  test("[] operator always returns null", () {
+    final empty = emptyMap();
+
+    expect(empty[0], isNull);
+    expect(empty[1], isNull);
+    expect(empty[-1], isNull);
+    expect(empty[null], isNull);
+  });
+
+  test("is equals to another empty map", () {
+    final empty0 = emptyMap();
+    final empty1 = emptyMap();
+
+    expect(empty0, equals(empty1));
+    expect(empty0.hashCode, equals(empty1.hashCode));
+  });
+
+  test("empty lists of different type are equal", () {
+    final empty0 = emptyMap<int, String>();
+    final empty1 = emptyMap<String, Object>();
+
+    expect(empty0, equals(empty1));
+    expect(empty0.hashCode, equals(empty1.hashCode));
+  });
+
+  test("is same as empty mutable map", () {
+    final empty0 = emptyMap<int, String>();
+    final empty1 = mutableMapFrom();
+
+    expect(empty0, equals(empty1));
+    expect(empty0.hashCode, equals(empty1.hashCode));
+  });
+
+  test("asMap has zero length", () {
+    final Map<String, int> map = emptyMap<String, int>().asMap();
+    expect(map.length, 0);
+  });
+  if (mutable) {
+    test("asMap is mutable", () {
+      final original = emptyMap<String, int>();
+      final Map<String, int> map = original.asMap();
+      map["a"] = 1;
+      expect(map["a"], 1);
+      expect(original["a"], 1);
     });
-
-    test("contains nothing", () {
-      expect(emptyMap<String, String>().containsKey("asdf"), isFalse);
-      expect(emptyMap<String, String>().containsValue("asdf"), isFalse);
-      expect(emptyMap<int, int>().containsKey(null), isFalse);
-      expect(emptyMap<int, int>().containsValue(null), isFalse);
-      expect(emptyMap<int, int>().containsKey(0), isFalse);
-      expect(emptyMap<int, int>().containsValue(0), isFalse);
-      expect(emptyMap<List, List>().containsKey([]), isFalse);
-      expect(emptyMap<List, List>().containsValue([]), isFalse);
-    });
-
-    test("entries have correct type", () {
-      final map = emptyMap<int, List<String>>();
-      expect(
-          map.entries.runtimeType.toString(), contains("<int, List<String>>"));
-    });
-
-    test("values iterator has no next", () {
-      final empty = emptyMap();
-      expect(empty.values.iterator().hasNext(), isFalse);
-      expect(() => empty.values.iterator().next(),
-          throwsA(const TypeMatcher<NoSuchElementException>()));
-    });
-
-    test("keys iterator has no next", () {
-      final empty = emptyMap();
-      expect(empty.keys.iterator().hasNext(), isFalse);
-      expect(() => empty.keys.iterator().next(),
-          throwsA(const TypeMatcher<NoSuchElementException>()));
-    });
-
-    test("is empty", () {
-      final empty = emptyMap<String, Object>();
-
-      expect(empty.isEmpty(), isTrue);
-    });
-
-    test("get always returns null", () {
-      final empty = emptyMap();
-
-      expect(empty.get(0), isNull);
-      expect(empty.get(1), isNull);
-      expect(empty.get(-1), isNull);
-      expect(empty.get(null), isNull);
-    });
-    test("[] operator always returns null", () {
-      final empty = emptyMap();
-
-      expect(empty[0], isNull);
-      expect(empty[1], isNull);
-      expect(empty[-1], isNull);
-      expect(empty[null], isNull);
-    });
-
-    test("is equals to another empty map", () {
-      final empty0 = emptyMap();
-      final empty1 = emptyMap();
-
-      expect(empty0, equals(empty1));
-      expect(empty0.hashCode, equals(empty1.hashCode));
-    });
-
-    test("empty lists of different type are equal", () {
-      final empty0 = emptyMap<int, String>();
-      final empty1 = emptyMap<String, Object>();
-
-      expect(empty0, equals(empty1));
-      expect(empty0.hashCode, equals(empty1.hashCode));
-    });
-
-    test("is same as empty mutable map", () {
-      final empty0 = emptyMap<int, String>();
-      final empty1 = mutableMapFrom();
-
-      expect(empty0, equals(empty1));
-      expect(empty0.hashCode, equals(empty1.hashCode));
-    });
-
-    test("asMap has zero length", () {
+  } else {
+    test("asMap is immutable", () {
       final Map<String, int> map = emptyMap<String, int>().asMap();
-      expect(map.length, 0);
+      final e = catchException<UnsupportedError>(() => map["a"] = 1);
+      expect(e.message, contains("unmodifiable"));
     });
-    if (mutable) {
-      test("asMap is mutable", () {
-        final original = emptyMap<String, int>();
-        final Map<String, int> map = original.asMap();
-        map["a"] = 1;
-        expect(map["a"], 1);
-        expect(original["a"], 1);
-      });
-    } else {
-      test("asMap is immutable", () {
-        final Map<String, int> map = emptyMap<String, int>().asMap();
-        final e = catchException<UnsupportedError>(() => map["a"] = 1);
-        expect(e.message, contains("unmodifiable"));
-      });
-    }
+  }
 
-    test("dart property has zero length", () {
+  test("dart property has zero length", () {
+    final Map<String, int> map = emptyMap<String, int>().dart;
+    expect(map.length, 0);
+  });
+  if (mutable) {
+    test("dart property is mutating original collection", () {
+      final original = emptyMap<String, int>();
+      final Map<String, int> map = original.dart;
+      map["a"] = 1;
+      expect(map["a"], 1);
+      expect(original["a"], 1);
+    });
+  } else {
+    test("dart property is immutable", () {
       final Map<String, int> map = emptyMap<String, int>().dart;
-      expect(map.length, 0);
+      final e = catchException<UnsupportedError>(() => map["a"] = 1);
+      expect(e.message, contains("unmodifiable"));
     });
-    if (mutable) {
-      test("dart property is mutating original collection", () {
-        final original = emptyMap<String, int>();
-        final Map<String, int> map = original.dart;
-        map["a"] = 1;
-        expect(map["a"], 1);
-        expect(original["a"], 1);
-      });
-    } else {
-      test("dart property is immutable", () {
-        final Map<String, int> map = emptyMap<String, int>().dart;
-        final e = catchException<UnsupportedError>(() => map["a"] = 1);
-        expect(e.message, contains("unmodifiable"));
-      });
+  }
+
+  test("containsKeyalways returns false", () {
+    expect(emptyMap().containsKey(2), isFalse);
+    expect(emptyMap().containsKey(null), isFalse);
+    expect(emptyMap().containsKey(""), isFalse);
+  });
+  test("containsValuealways returns false", () {
+    expect(emptyMap().containsValue(2), isFalse);
+    expect(emptyMap().containsValue(null), isFalse);
+    expect(emptyMap().containsValue(""), isFalse);
+  });
+  test("getOrDefault always returns the default", () {
+    expect(emptyMap().getOrDefault(0, "Ditto"), equals("Ditto"));
+  });
+  test("isEmpty always returns true", () {
+    expect(mapFrom().isEmpty(), isTrue);
+  });
+  test("values always is empty", () {
+    expect(emptyMap().values.isEmpty(), isTrue);
+  });
+  test("entries always is empty", () {
+    expect(emptyMap().entries.isEmpty(), isTrue);
+  });
+
+  test("iter via for loop", () {
+    final pokemon = emptyMap();
+
+    final values = mutableListOf();
+    final keys = mutableListOf();
+    for (final p in pokemon.iter) {
+      keys.add(p.key);
+      values.add(p.value);
     }
-
-    test("containsKeyalways returns false", () {
-      expect(emptyMap().containsKey(2), isFalse);
-      expect(emptyMap().containsKey(null), isFalse);
-      expect(emptyMap().containsKey(""), isFalse);
-    });
-    test("containsValuealways returns false", () {
-      expect(emptyMap().containsValue(2), isFalse);
-      expect(emptyMap().containsValue(null), isFalse);
-      expect(emptyMap().containsValue(""), isFalse);
-    });
-    test("getOrDefault always returns the default", () {
-      expect(emptyMap().getOrDefault(0, "Ditto"), equals("Ditto"));
-    });
-    test("isEmpty always returns true", () {
-      expect(mapFrom().isEmpty(), isTrue);
-    });
-    test("values always is empty", () {
-      expect(emptyMap().values.isEmpty(), isTrue);
-    });
-    test("entries always is empty", () {
-      expect(emptyMap().entries.isEmpty(), isTrue);
-    });
-
-    test("iter via for loop", () {
-      final pokemon = emptyMap();
-
-      final values = mutableListOf();
-      final keys = mutableListOf();
-      for (final p in pokemon.iter) {
-        keys.add(p.key);
-        values.add(p.value);
-      }
-      expect(values.isEmpty(), isTrue);
-      expect(keys.isEmpty(), isTrue);
-    });
+    expect(values.isEmpty(), isTrue);
+    expect(keys.isEmpty(), isTrue);
   });
 }

--- a/test/collection/map_empty_test.dart
+++ b/test/collection/map_empty_test.dart
@@ -133,9 +133,11 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap, {bool mutable = true}) {
     });
     if (mutable) {
       test("asMap is mutable", () {
-        final Map<String, int> map = emptyMap<String, int>().asMap();
+        final original = emptyMap<String, int>();
+        final Map<String, int> map = original.asMap();
         map["a"] = 1;
         expect(map["a"], 1);
+        expect(original["a"], 1);
       });
     } else {
       test("asMap is immutable", () {
@@ -144,6 +146,27 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap, {bool mutable = true}) {
         expect(e.message, contains("unmodifiable"));
       });
     }
+
+    test("dart property has zero length", () {
+      final Map<String, int> map = emptyMap<String, int>().dart;
+      expect(map.length, 0);
+    });
+    if (mutable) {
+      test("dart property is mutating original collection", () {
+        final original = emptyMap<String, int>();
+        final Map<String, int> map = original.dart;
+        map["a"] = 1;
+        expect(map["a"], 1);
+        expect(original["a"], 1);
+      });
+    } else {
+      test("dart property is immutable", () {
+        final Map<String, int> map = emptyMap<String, int>().dart;
+        final e = catchException<UnsupportedError>(() => map["a"] = 1);
+        expect(e.message, contains("unmodifiable"));
+      });
+    }
+
     test("containsKeyalways returns false", () {
       expect(emptyMap().containsKey(2), isFalse);
       expect(emptyMap().containsKey(null), isFalse);

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -15,29 +15,33 @@ void main() {
   });
   group("mutableMapFrom", () {
     testMap(<K, V>() => mutableMapFrom<K, V>(),
-        <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
+        <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map),
+        mutable: true);
   });
   group("KtMutableMap.from", () {
     testMap(<K, V>() => KtMutableMap<K, V>.empty(),
-        <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
+        <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map),
+        mutable: true);
   });
   group("hashMapFrom", () {
     testMap(<K, V>() => hashMapFrom<K, V>(),
         <K, V>(Map<K, V> map) => hashMapFrom<K, V>(map),
-        ordered: false);
+        ordered: false, mutable: true);
   });
   group("KHashMap", () {
     testMap(<K, V>() => KtHashMap<K, V>.empty(),
         <K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
-        ordered: false);
+        ordered: false, mutable: true);
   });
   group("linkedMapFrom", () {
     testMap(<K, V>() => linkedMapFrom<K, V>(),
-        <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
+        <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map),
+        mutable: true);
   });
   group("KLinkedMap", () {
     testMap(<K, V>() => KtLinkedMap<K, V>.empty(),
-        <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
+        <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map),
+        mutable: true);
   });
   group("ThirdPartyMap", () {
     testMap(<K, V>() => ThirdPartyMap<K, V>(),
@@ -47,7 +51,7 @@ void main() {
 
 void testMap(KtMap<K, V> Function<K, V>() emptyMap,
     KtMap<K, V> Function<K, V>(Map<K, V> map) mapFrom,
-    {bool ordered = true}) {
+    {bool ordered = true, bool mutable = false}) {
   final pokemon = mapFrom({
     1: "Bulbasaur",
     2: "Ivysaur",
@@ -99,6 +103,24 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap,
       final e = catchException<ArgumentError>(() => emptyMap().any(null));
       expect(e.message, allOf(contains("null"), contains("predicate")));
     });
+  });
+
+  group("dart property", () {
+    if (!mutable) {
+      test("is immutable", () {
+        final Map<String, int> map = emptyMap<String, int>().dart;
+        final e = catchException<UnsupportedError>(() => map["a"] = 1);
+        expect(e.message, contains("unmodifiable"));
+      });
+    } else {
+      test("allows mutation of original map", () {
+        final original = emptyMap<String, int>();
+        final Map<String, int> map = original.dart;
+        map["a"] = 1;
+        expect(map["a"], 1);
+        expect(original["a"], 1);
+      });
+    }
   });
 
   group("filter", () {

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -5,47 +5,49 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mapFrom", () {
-    testMap(<K, V>() => emptyMap<K, V>(),
-        <K, V>(Map<K, V> map) => mapFrom<K, V>(map));
-  });
-  group("KtMap.from", () {
-    testMap(<K, V>() => emptyMap<K, V>(),
-        <K, V>(Map<K, V> map) => KtMap<K, V>.from(map));
-  });
-  group("mutableMapFrom", () {
-    testMap(<K, V>() => mutableMapFrom<K, V>(),
-        <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map),
-        mutable: true);
-  });
-  group("KtMutableMap.from", () {
-    testMap(<K, V>() => KtMutableMap<K, V>.empty(),
-        <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map),
-        mutable: true);
-  });
-  group("hashMapFrom", () {
-    testMap(<K, V>() => hashMapFrom<K, V>(),
-        <K, V>(Map<K, V> map) => hashMapFrom<K, V>(map),
-        ordered: false, mutable: true);
-  });
-  group("KHashMap", () {
-    testMap(<K, V>() => KtHashMap<K, V>.empty(),
-        <K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
-        ordered: false, mutable: true);
-  });
-  group("linkedMapFrom", () {
-    testMap(<K, V>() => linkedMapFrom<K, V>(),
-        <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map),
-        mutable: true);
-  });
-  group("KLinkedMap", () {
-    testMap(<K, V>() => KtLinkedMap<K, V>.empty(),
-        <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map),
-        mutable: true);
-  });
-  group("ThirdPartyMap", () {
-    testMap(<K, V>() => ThirdPartyMap<K, V>(),
-        <K, V>(Map<K, V> map) => ThirdPartyMap<K, V>(map));
+  group("KtMapExtensions", () {
+    group("mapFrom", () {
+      testMap(<K, V>() => emptyMap<K, V>(),
+          <K, V>(Map<K, V> map) => mapFrom<K, V>(map));
+    });
+    group("KtMap.from", () {
+      testMap(<K, V>() => emptyMap<K, V>(),
+          <K, V>(Map<K, V> map) => KtMap<K, V>.from(map));
+    });
+    group("mutableMapFrom", () {
+      testMap(<K, V>() => mutableMapFrom<K, V>(),
+          <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map),
+          mutable: true);
+    });
+    group("KtMutableMap.from", () {
+      testMap(<K, V>() => KtMutableMap<K, V>.empty(),
+          <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map),
+          mutable: true);
+    });
+    group("hashMapFrom", () {
+      testMap(<K, V>() => hashMapFrom<K, V>(),
+          <K, V>(Map<K, V> map) => hashMapFrom<K, V>(map),
+          ordered: false, mutable: true);
+    });
+    group("KtHashMap", () {
+      testMap(<K, V>() => KtHashMap<K, V>.empty(),
+          <K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
+          ordered: false, mutable: true);
+    });
+    group("linkedMapFrom", () {
+      testMap(<K, V>() => linkedMapFrom<K, V>(),
+          <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map),
+          mutable: true);
+    });
+    group("KtLinkedMap", () {
+      testMap(<K, V>() => KtLinkedMap<K, V>.empty(),
+          <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map),
+          mutable: true);
+    });
+    group("ThirdPartyMap", () {
+      testMap(<K, V>() => ThirdPartyMap<K, V>(),
+          <K, V>(Map<K, V> map) => ThirdPartyMap<K, V>(map));
+    });
   });
 }
 

--- a/test/collection/map_mutable_extensions_test.dart
+++ b/test/collection/map_mutable_extensions_test.dart
@@ -4,31 +4,33 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mutableMapFrom", () {
-    testMutableMap(<K, V>() => mutableMapFrom<K, V>(),
-        <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
-  });
-  group("KtMutableMap", () {
-    testMutableMap(<K, V>() => KtMutableMap<K, V>.empty(),
-        <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
-  });
-  group("hashMapFrom", () {
-    testMutableMap(<K, V>() => hashMapFrom<K, V>(),
-        <K, V>(Map<K, V> map) => hashMapFrom<K, V>(map),
-        ordered: false);
-  });
-  group("KHashMap", () {
-    testMutableMap(<K, V>() => KtHashMap<K, V>.empty(),
-        <K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
-        ordered: false);
-  });
-  group("linkedMapFrom", () {
-    testMutableMap(<K, V>() => linkedMapFrom<K, V>(),
-        <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
-  });
-  group("KLinkedMap", () {
-    testMutableMap(<K, V>() => KtLinkedMap<K, V>.empty(),
-        <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
+  group("KtMutableMapExtensions", () {
+    group("mutableMapFrom", () {
+      testMutableMap(<K, V>() => mutableMapFrom<K, V>(),
+          <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
+    });
+    group("KtMutableMap", () {
+      testMutableMap(<K, V>() => KtMutableMap<K, V>.empty(),
+          <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
+    });
+    group("hashMapFrom", () {
+      testMutableMap(<K, V>() => hashMapFrom<K, V>(),
+          <K, V>(Map<K, V> map) => hashMapFrom<K, V>(map),
+          ordered: false);
+    });
+    group("KtHashMap", () {
+      testMutableMap(<K, V>() => KtHashMap<K, V>.empty(),
+          <K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
+          ordered: false);
+    });
+    group("linkedMapFrom", () {
+      testMutableMap(<K, V>() => linkedMapFrom<K, V>(),
+          <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
+    });
+    group("KtLinkedMap", () {
+      testMutableMap(<K, V>() => KtLinkedMap<K, V>.empty(),
+          <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
+    });
   });
 }
 

--- a/test/collection/map_mutable_extensions_test.dart
+++ b/test/collection/map_mutable_extensions_test.dart
@@ -100,6 +100,16 @@ void testMutableMap(KtMutableMap<K, V> Function<K, V>() emptyMap,
     });
   });
 
+  group("dart property", () {
+    test("allows mutation of original map", () {
+      final original = emptyMap<String, int>();
+      final Map<String, int> map = original.dart;
+      map["a"] = 1;
+      expect(map["a"], 1);
+      expect(original["a"], 1);
+    });
+  });
+
   group("get", () {
     test("get", () {
       final pokemon = mutableMapFrom({

--- a/test/collection/map_mutable_test.dart
+++ b/test/collection/map_mutable_test.dart
@@ -4,25 +4,27 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mutableMapFrom", () {
-    testMutableMap(<K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
-  });
-  group("KtMutableMap.from", () {
-    testMutableMap(<K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
-  });
-  group("hashMapFrom", () {
-    testMutableMap(<K, V>(Map<K, V> map) => hashMapFrom<K, V>(map),
-        ordered: false);
-  });
-  group("KHashMap", () {
-    testMutableMap(<K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
-        ordered: false);
-  });
-  group("linkedMapFrom", () {
-    testMutableMap(<K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
-  });
-  group("KLinkedMap", () {
-    testMutableMap(<K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
+  group("KtMutableMap", () {
+    group("mutableMapFrom", () {
+      testMutableMap(<K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
+    });
+    group("KtMutableMap.from", () {
+      testMutableMap(<K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
+    });
+    group("hashMapFrom", () {
+      testMutableMap(<K, V>(Map<K, V> map) => hashMapFrom<K, V>(map),
+          ordered: false);
+    });
+    group("KtHashMap", () {
+      testMutableMap(<K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
+          ordered: false);
+    });
+    group("linkedMapFrom", () {
+      testMutableMap(<K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
+    });
+    group("KtLinkedMap", () {
+      testMutableMap(<K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
+    });
   });
 }
 

--- a/test/collection/map_test.dart
+++ b/test/collection/map_test.dart
@@ -4,29 +4,31 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mapFrom", () {
-    testMap(<K, V>(Map<K, V> map) => mapFrom<K, V>(map));
-  });
-  group("KtMap.from", () {
-    testMap(<K, V>(Map<K, V> map) => KtMap<K, V>.from(map));
-  });
-  group("mutableMapFrom", () {
-    testMap(<K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
-  });
-  group("KtMutableMap.from", () {
-    testMap(<K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
-  });
-  group("hashMapFrom", () {
-    testMap(<K, V>(Map<K, V> map) => hashMapFrom<K, V>(map));
-  });
-  group("KHashMap", () {
-    testMap(<K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map));
-  });
-  group("linkedMapOf", () {
-    testMap(<K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
-  });
-  group("KLinkedMap", () {
-    testMap(<K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
+  group("KtMap", () {
+    group("mapFrom", () {
+      testMap(<K, V>(Map<K, V> map) => mapFrom<K, V>(map));
+    });
+    group("KtMap.from", () {
+      testMap(<K, V>(Map<K, V> map) => KtMap<K, V>.from(map));
+    });
+    group("mutableMapFrom", () {
+      testMap(<K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
+    });
+    group("KtMutableMap.from", () {
+      testMap(<K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
+    });
+    group("hashMapFrom", () {
+      testMap(<K, V>(Map<K, V> map) => hashMapFrom<K, V>(map));
+    });
+    group("KtHashMap", () {
+      testMap(<K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map));
+    });
+    group("linkedMapOf", () {
+      testMap(<K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
+    });
+    group("KtLinkedMap", () {
+      testMap(<K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
+    });
   });
 }
 

--- a/test/collection/set_empty_test.dart
+++ b/test/collection/set_empty_test.dart
@@ -75,6 +75,15 @@ void testEmptySet(KtSet<T> Function<T>() emptySet, {bool mutable = false}) {
     });
 
     if (mutable) {
+      test("dart property allows mutation", () {
+        final ktSet = emptySet();
+        expect(ktSet.isEmpty(), isTrue);
+        final dartSet = ktSet.dart;
+        dartSet.add("asdf");
+        expect(dartSet.length, 1);
+        expect(ktSet.size, 1);
+      });
+
       test("empty set asSet allows mutation", () {
         final ktSet = emptySet();
         expect(ktSet.isEmpty(), isTrue);
@@ -94,6 +103,14 @@ void testEmptySet(KtSet<T> Function<T>() emptySet, {bool mutable = false}) {
         expect(ktSet.size, 1);
       });
     } else {
+      test("dart property doesn't allow mutation", () {
+        final ktSet = emptySet();
+        expect(ktSet.isEmpty(), isTrue);
+        final e =
+            catchException<UnsupportedError>(() => ktSet.dart.add("asdf"));
+        expect(e.message, contains("unmodifiable"));
+      });
+
       test("empty set asSet doesn't allow mutation", () {
         final ktSet = emptySet();
         expect(ktSet.isEmpty(), isTrue);

--- a/test/collection/set_empty_test.dart
+++ b/test/collection/set_empty_test.dart
@@ -4,129 +4,128 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("emptySet", () {
-    testEmptySet(<T>() => emptySet<T>());
-  });
-  group("KtSet.empty", () {
-    testEmptySet(<T>() => KtSet<T>.empty());
-  });
-  group("KtSet.of", () {
-    testEmptySet(<T>() => KtSet<T>.of());
-  });
-  group("KtSet.from", () {
-    testEmptySet(<T>() => KtSet<T>.from());
-  });
-  group("mutableSetFrom", () {
-    testEmptySet(<T>() => mutableSetFrom<T>(), mutable: true);
-  });
-  group("mutableSetOf", () {
-    testEmptySet(<T>() => mutableSetOf<T>(), mutable: true);
-  });
-  group("KMutableSet.of", () {
-    testEmptySet(<T>() => KtMutableSet<T>.of(), mutable: true);
-  });
-  group("KMutableSet.from", () {
-    testEmptySet(<T>() => KtMutableSet<T>.from(), mutable: true);
-  });
-  group("KHashSet.from", () {
-    testEmptySet(<T>() => KtHashSet<T>.from(), mutable: true);
-  });
-  group("KHashSet.of", () {
-    testEmptySet(<T>() => KtHashSet<T>.of(), mutable: true);
-  });
-  group("KLinkedSet.from", () {
-    testEmptySet(<T>() => KtLinkedSet<T>.from(), mutable: true);
-  });
-  group("KLinkedSet.of", () {
-    testEmptySet(<T>() => KtLinkedSet<T>.of(), mutable: true);
+  group("EmptySet", () {
+    group("emptySet", () {
+      testEmptySet(<T>() => emptySet<T>());
+    });
+    group("KtSet.empty", () {
+      testEmptySet(<T>() => KtSet<T>.empty());
+    });
+    group("KtSet.of", () {
+      testEmptySet(<T>() => KtSet<T>.of());
+    });
+    group("KtSet.from", () {
+      testEmptySet(<T>() => KtSet<T>.from());
+    });
+    group("mutableSetFrom", () {
+      testEmptySet(<T>() => mutableSetFrom<T>(), mutable: true);
+    });
+    group("mutableSetOf", () {
+      testEmptySet(<T>() => mutableSetOf<T>(), mutable: true);
+    });
+    group("KtMutableSet.of", () {
+      testEmptySet(<T>() => KtMutableSet<T>.of(), mutable: true);
+    });
+    group("KtMutableSet.from", () {
+      testEmptySet(<T>() => KtMutableSet<T>.from(), mutable: true);
+    });
+    group("KtHashSet.from", () {
+      testEmptySet(<T>() => KtHashSet<T>.from(), mutable: true);
+    });
+    group("KtHashSet.of", () {
+      testEmptySet(<T>() => KtHashSet<T>.of(), mutable: true);
+    });
+    group("KtLinkedSet.from", () {
+      testEmptySet(<T>() => KtLinkedSet<T>.from(), mutable: true);
+    });
+    group("KtLinkedSet.of", () {
+      testEmptySet(<T>() => KtLinkedSet<T>.of(), mutable: true);
+    });
   });
 }
 
 void testEmptySet(KtSet<T> Function<T>() emptySet, {bool mutable = false}) {
-  group("basic methods", () {
-    test("empty iterator", () {
-      final iterator = emptySet().iterator();
-      expect(iterator.hasNext(), isFalse);
-      expect(() => iterator.next(),
-          throwsA(const TypeMatcher<NoSuchElementException>()));
-    });
-
-    test("contains nothing", () {
-      final set = emptySet();
-      expect(set.contains("a"), isFalse);
-      expect(set.contains("b"), isFalse);
-      expect(set.contains("c"), isFalse);
-      expect(set.contains(null), isFalse);
-      expect(set.contains(""), isFalse);
-    });
-
-    test("iterator have correct type", () {
-      final set = emptySet<Map<int, String>>();
-      expect(
-          set.iterator().runtimeType.toString(), contains("Map<int, String>>"));
-    });
-
-    test("is empty", () {
-      expect(emptySet().isEmpty(), isTrue);
-    });
-    test("equals although differnt types (subtypes)", () {
-      expect(emptySet<int>(), emptySet<num>());
-      expect(emptySet<num>(), emptySet<int>());
-    });
-
-    if (mutable) {
-      test("dart property allows mutation", () {
-        final ktSet = emptySet();
-        expect(ktSet.isEmpty(), isTrue);
-        final dartSet = ktSet.dart;
-        dartSet.add("asdf");
-        expect(dartSet.length, 1);
-        expect(ktSet.size, 1);
-      });
-
-      test("empty set asSet allows mutation", () {
-        final ktSet = emptySet();
-        expect(ktSet.isEmpty(), isTrue);
-        final dartSet = ktSet.asSet();
-        dartSet.add("asdf");
-        expect(dartSet.length, 1);
-        expect(ktSet.size, 1);
-      });
-
-      test("empty set set allows mutation", () {
-        final ktSet = emptySet();
-        expect(ktSet.isEmpty(), isTrue);
-        // ignore: deprecated_member_use_from_same_package
-        final dartSet = ktSet.set;
-        dartSet.add("asdf");
-        expect(dartSet.length, 1);
-        expect(ktSet.size, 1);
-      });
-    } else {
-      test("dart property doesn't allow mutation", () {
-        final ktSet = emptySet();
-        expect(ktSet.isEmpty(), isTrue);
-        final e =
-            catchException<UnsupportedError>(() => ktSet.dart.add("asdf"));
-        expect(e.message, contains("unmodifiable"));
-      });
-
-      test("empty set asSet doesn't allow mutation", () {
-        final ktSet = emptySet();
-        expect(ktSet.isEmpty(), isTrue);
-        final e =
-            catchException<UnsupportedError>(() => ktSet.asSet().add("asdf"));
-        expect(e.message, contains("unmodifiable"));
-      });
-
-      test("empty set set doesn't allow mutation", () {
-        final ktSet = emptySet();
-        expect(ktSet.isEmpty(), isTrue);
-        final e =
-            // ignore: deprecated_member_use_from_same_package
-            catchException<UnsupportedError>(() => ktSet.set.add("asdf"));
-        expect(e.message, contains("unmodifiable"));
-      });
-    }
+  test("empty iterator", () {
+    final iterator = emptySet().iterator();
+    expect(iterator.hasNext(), isFalse);
+    expect(() => iterator.next(),
+        throwsA(const TypeMatcher<NoSuchElementException>()));
   });
+
+  test("contains nothing", () {
+    final set = emptySet();
+    expect(set.contains("a"), isFalse);
+    expect(set.contains("b"), isFalse);
+    expect(set.contains("c"), isFalse);
+    expect(set.contains(null), isFalse);
+    expect(set.contains(""), isFalse);
+  });
+
+  test("iterator have correct type", () {
+    final set = emptySet<Map<int, String>>();
+    expect(
+        set.iterator().runtimeType.toString(), contains("Map<int, String>>"));
+  });
+
+  test("is empty", () {
+    expect(emptySet().isEmpty(), isTrue);
+  });
+  test("equals although differnt types (subtypes)", () {
+    expect(emptySet<int>(), emptySet<num>());
+    expect(emptySet<num>(), emptySet<int>());
+  });
+
+  if (mutable) {
+    test("dart property allows mutation", () {
+      final ktSet = emptySet();
+      expect(ktSet.isEmpty(), isTrue);
+      final dartSet = ktSet.dart;
+      dartSet.add("asdf");
+      expect(dartSet.length, 1);
+      expect(ktSet.size, 1);
+    });
+
+    test("empty set asSet allows mutation", () {
+      final ktSet = emptySet();
+      expect(ktSet.isEmpty(), isTrue);
+      final dartSet = ktSet.asSet();
+      dartSet.add("asdf");
+      expect(dartSet.length, 1);
+      expect(ktSet.size, 1);
+    });
+
+    test("empty set set allows mutation", () {
+      final ktSet = emptySet();
+      expect(ktSet.isEmpty(), isTrue);
+      // ignore: deprecated_member_use_from_same_package
+      final dartSet = ktSet.set;
+      dartSet.add("asdf");
+      expect(dartSet.length, 1);
+      expect(ktSet.size, 1);
+    });
+  } else {
+    test("dart property doesn't allow mutation", () {
+      final ktSet = emptySet();
+      expect(ktSet.isEmpty(), isTrue);
+      final e = catchException<UnsupportedError>(() => ktSet.dart.add("asdf"));
+      expect(e.message, contains("unmodifiable"));
+    });
+
+    test("empty set asSet doesn't allow mutation", () {
+      final ktSet = emptySet();
+      expect(ktSet.isEmpty(), isTrue);
+      final e =
+          catchException<UnsupportedError>(() => ktSet.asSet().add("asdf"));
+      expect(e.message, contains("unmodifiable"));
+    });
+
+    test("empty set set doesn't allow mutation", () {
+      final ktSet = emptySet();
+      expect(ktSet.isEmpty(), isTrue);
+      final e =
+          // ignore: deprecated_member_use_from_same_package
+          catchException<UnsupportedError>(() => ktSet.set.add("asdf"));
+      expect(e.message, contains("unmodifiable"));
+    });
+  }
 }

--- a/test/collection/set_extensions_test.dart
+++ b/test/collection/set_extensions_test.dart
@@ -1,7 +1,7 @@
 import "package:kt_dart/collection.dart";
 import "package:test/test.dart";
 
-import '../test/assert_dart.dart';
+import "../test/assert_dart.dart";
 
 void main() {
   group("KtSet", () {

--- a/test/collection/set_extensions_test.dart
+++ b/test/collection/set_extensions_test.dart
@@ -4,170 +4,174 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("KtSet", () {
-    testSet(
-      emptySet: <T>() => KtSet<T>.empty(),
-      setOf: <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          KtSet<T>.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      setFrom: <T>([Iterable<T> iterable = const []]) => KtSet.from(iterable),
-      mutable: false,
-    );
-  });
-  group("set", () {
-    testSet(
-      emptySet: <T>() => emptySet<T>(),
-      setOf: <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          setOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      setFrom: <T>([Iterable<T> iterable = const []]) => setFrom(iterable),
-      mutable: false,
-    );
-  });
-  group("KtMutableSet", () {
-    testSet(
-      emptySet: <T>() => KtMutableSet<T>.empty(),
-      setOf: <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          KtMutableSet<T>.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      setFrom: <T>([Iterable<T> iterable = const []]) =>
-          KtMutableSet.from(iterable),
-      mutable: true,
-    );
-  });
-  group("mutableSet", () {
-    testSet(
-      emptySet: <T>() => mutableSetOf<T>(),
-      setOf: <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          mutableSetOf(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      setFrom: <T>([Iterable<T> iterable = const []]) =>
-          mutableSetFrom(iterable),
-      mutable: true,
-    );
-  });
+  group("KtSetExtensions", () {
+    group("KtSet", () {
+      testSet(
+        emptySet: <T>() => KtSet<T>.empty(),
+        setOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            KtSet<T>.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        setFrom: <T>([Iterable<T> iterable = const []]) => KtSet.from(iterable),
+        mutable: false,
+      );
+    });
+    group("set", () {
+      testSet(
+        emptySet: <T>() => emptySet<T>(),
+        setOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            setOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        setFrom: <T>([Iterable<T> iterable = const []]) => setFrom(iterable),
+        mutable: false,
+      );
+    });
+    group("KtMutableSet", () {
+      testSet(
+        emptySet: <T>() => KtMutableSet<T>.empty(),
+        setOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            KtMutableSet<T>.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        setFrom: <T>([Iterable<T> iterable = const []]) =>
+            KtMutableSet.from(iterable),
+        mutable: true,
+      );
+    });
+    group("mutableSet", () {
+      testSet(
+        emptySet: <T>() => mutableSetOf<T>(),
+        setOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            mutableSetOf(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        setFrom: <T>([Iterable<T> iterable = const []]) =>
+            mutableSetFrom(iterable),
+        mutable: true,
+      );
+    });
 
-  group("KtHashSet", () {
-    testSet(
-      emptySet: <T>() => KtHashSet<T>.empty(),
-      setOf: <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          KtHashSet<T>.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      setFrom: <T>([Iterable<T> iterable = const []]) =>
-          KtHashSet.from(iterable),
-      mutable: true,
-    );
-  });
-  group("hashSet", () {
-    testSet(
-      emptySet: <T>() => hashSetOf<T>(),
-      setOf: <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          hashSetOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      setFrom: <T>([Iterable<T> iterable = const []]) => hashSetFrom(iterable),
-      mutable: true,
-    );
-  });
+    group("KtHashSet", () {
+      testSet(
+        emptySet: <T>() => KtHashSet<T>.empty(),
+        setOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            KtHashSet<T>.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        setFrom: <T>([Iterable<T> iterable = const []]) =>
+            KtHashSet.from(iterable),
+        mutable: true,
+      );
+    });
+    group("hashSet", () {
+      testSet(
+        emptySet: <T>() => hashSetOf<T>(),
+        setOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            hashSetOf(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        setFrom: <T>([Iterable<T> iterable = const []]) =>
+            hashSetFrom(iterable),
+        mutable: true,
+      );
+    });
 
-  group("KtLinkedSet", () {
-    testSet(
-      emptySet: <T>() => KtLinkedSet<T>.empty(),
-      setOf: <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          KtLinkedSet<T>.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      setFrom: <T>([Iterable<T> iterable = const []]) =>
-          KtLinkedSet.from(iterable),
-      mutable: true,
-    );
-  });
-  group("linkedSet", () {
-    testSet(
-      emptySet: <T>() => linkedSetOf<T>(),
-      setOf: <T>(
-              [T arg0,
-              T arg1,
-              T arg2,
-              T arg3,
-              T arg4,
-              T arg5,
-              T arg6,
-              T arg7,
-              T arg8,
-              T arg9]) =>
-          linkedSetOf(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      setFrom: <T>([Iterable<T> iterable = const []]) =>
-          linkedSetFrom(iterable),
-      mutable: true,
-    );
+    group("KtLinkedSet", () {
+      testSet(
+        emptySet: <T>() => KtLinkedSet<T>.empty(),
+        setOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            KtLinkedSet<T>.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        setFrom: <T>([Iterable<T> iterable = const []]) =>
+            KtLinkedSet.from(iterable),
+        mutable: true,
+      );
+    });
+    group("linkedSet", () {
+      testSet(
+        emptySet: <T>() => linkedSetOf<T>(),
+        setOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            linkedSetOf(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        setFrom: <T>([Iterable<T> iterable = const []]) =>
+            linkedSetFrom(iterable),
+        mutable: true,
+      );
+    });
   });
 }
 

--- a/test/collection/set_extensions_test.dart
+++ b/test/collection/set_extensions_test.dart
@@ -1,0 +1,228 @@
+import "package:kt_dart/collection.dart";
+import "package:test/test.dart";
+
+import '../test/assert_dart.dart';
+
+void main() {
+  group("KtSet", () {
+    testSet(
+      emptySet: <T>() => KtSet<T>.empty(),
+      setOf: <T>(
+              [T arg0,
+              T arg1,
+              T arg2,
+              T arg3,
+              T arg4,
+              T arg5,
+              T arg6,
+              T arg7,
+              T arg8,
+              T arg9]) =>
+          KtSet<T>.of(
+              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+      setFrom: <T>([Iterable<T> iterable = const []]) => KtSet.from(iterable),
+      mutable: false,
+    );
+  });
+  group("set", () {
+    testSet(
+      emptySet: <T>() => emptySet<T>(),
+      setOf: <T>(
+              [T arg0,
+              T arg1,
+              T arg2,
+              T arg3,
+              T arg4,
+              T arg5,
+              T arg6,
+              T arg7,
+              T arg8,
+              T arg9]) =>
+          setOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+      setFrom: <T>([Iterable<T> iterable = const []]) => setFrom(iterable),
+      mutable: false,
+    );
+  });
+  group("KtMutableSet", () {
+    testSet(
+      emptySet: <T>() => KtMutableSet<T>.empty(),
+      setOf: <T>(
+              [T arg0,
+              T arg1,
+              T arg2,
+              T arg3,
+              T arg4,
+              T arg5,
+              T arg6,
+              T arg7,
+              T arg8,
+              T arg9]) =>
+          KtMutableSet<T>.of(
+              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+      setFrom: <T>([Iterable<T> iterable = const []]) =>
+          KtMutableSet.from(iterable),
+      mutable: true,
+    );
+  });
+  group("mutableSet", () {
+    testSet(
+      emptySet: <T>() => mutableSetOf<T>(),
+      setOf: <T>(
+              [T arg0,
+              T arg1,
+              T arg2,
+              T arg3,
+              T arg4,
+              T arg5,
+              T arg6,
+              T arg7,
+              T arg8,
+              T arg9]) =>
+          mutableSetOf(
+              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+      setFrom: <T>([Iterable<T> iterable = const []]) =>
+          mutableSetFrom(iterable),
+      mutable: true,
+    );
+  });
+
+  group("KtHashSet", () {
+    testSet(
+      emptySet: <T>() => KtHashSet<T>.empty(),
+      setOf: <T>(
+              [T arg0,
+              T arg1,
+              T arg2,
+              T arg3,
+              T arg4,
+              T arg5,
+              T arg6,
+              T arg7,
+              T arg8,
+              T arg9]) =>
+          KtHashSet<T>.of(
+              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+      setFrom: <T>([Iterable<T> iterable = const []]) =>
+          KtHashSet.from(iterable),
+      mutable: true,
+    );
+  });
+  group("hashSet", () {
+    testSet(
+      emptySet: <T>() => hashSetOf<T>(),
+      setOf: <T>(
+              [T arg0,
+              T arg1,
+              T arg2,
+              T arg3,
+              T arg4,
+              T arg5,
+              T arg6,
+              T arg7,
+              T arg8,
+              T arg9]) =>
+          hashSetOf(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+      setFrom: <T>([Iterable<T> iterable = const []]) => hashSetFrom(iterable),
+      mutable: true,
+    );
+  });
+
+  group("KtLinkedSet", () {
+    testSet(
+      emptySet: <T>() => KtLinkedSet<T>.empty(),
+      setOf: <T>(
+              [T arg0,
+              T arg1,
+              T arg2,
+              T arg3,
+              T arg4,
+              T arg5,
+              T arg6,
+              T arg7,
+              T arg8,
+              T arg9]) =>
+          KtLinkedSet<T>.of(
+              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+      setFrom: <T>([Iterable<T> iterable = const []]) =>
+          KtLinkedSet.from(iterable),
+      mutable: true,
+    );
+  });
+  group("linkedSet", () {
+    testSet(
+      emptySet: <T>() => linkedSetOf<T>(),
+      setOf: <T>(
+              [T arg0,
+              T arg1,
+              T arg2,
+              T arg3,
+              T arg4,
+              T arg5,
+              T arg6,
+              T arg7,
+              T arg8,
+              T arg9]) =>
+          linkedSetOf(
+              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+      setFrom: <T>([Iterable<T> iterable = const []]) =>
+          linkedSetFrom(iterable),
+      mutable: true,
+    );
+  });
+}
+
+void testSet({
+  KtSet<T> Function<T>() emptySet,
+  KtSet<T> Function<T>(
+          [T arg0,
+          T arg1,
+          T arg2,
+          T arg3,
+          T arg4,
+          T arg5,
+          T arg6,
+          T arg7,
+          T arg8,
+          T arg9])
+      setOf,
+  KtSet<T> Function<T>([Iterable<T> iterable]) setFrom,
+  bool mutable = false,
+}) {
+  group("dart property", () {
+    test("dart property returns an empty list", () {
+      final dartList = emptySet<int>().dart;
+      expect(dartList.length, 0);
+    });
+
+    if (!mutable) {
+      test("dart property returns an unmodifiable list", () {
+        final dartList = emptySet<int>().dart;
+        final e = catchException<UnsupportedError>(() => dartList.add(1));
+        expect(e.message, contains("unmodifiable"));
+      });
+    } else {
+      test("dart property returns an modifiable list", () {
+        final original = setOf<int>();
+        final dartList = original.dart;
+        dartList.add(1);
+        expect(original, setOf(1));
+        expect(dartList, {1});
+      });
+    }
+  });
+
+  group("orEmpty", () {
+    test("null -> empty set", () {
+      const KtSet<int> set = null;
+      expect(set.orEmpty(), isNotNull);
+      expect(set.orEmpty(), isA<KtSet<int>>());
+      expect(set.orEmpty().isEmpty(), isTrue);
+      expect(set.orEmpty().size, 0);
+    });
+    test("set -> just return the set", () {
+      final KtSet<int> set = setOf(1, 2, 3);
+      expect(set.orEmpty(), set);
+      expect(identical(set.orEmpty(), set), isTrue);
+    });
+  });
+}

--- a/test/collection/set_mutable_extensions_test.dart
+++ b/test/collection/set_mutable_extensions_test.dart
@@ -1,0 +1,161 @@
+import "package:kt_dart/collection.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("KtMutableSetExtensions", () {
+    group("KtMutableSet", () {
+      testSet(
+        emptySet: <T>() => KtMutableSet<T>.empty(),
+        mutableSetOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            KtMutableSet<T>.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        mutableSetFrom: <T>([Iterable<T> iterable = const []]) =>
+            KtMutableSet.from(iterable),
+      );
+    });
+    group("mutableSet", () {
+      testSet(
+        emptySet: <T>() => mutableSetOf<T>(),
+        mutableSetOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            mutableSetOf(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        mutableSetFrom: <T>([Iterable<T> iterable = const []]) =>
+            mutableSetFrom(iterable),
+      );
+    });
+
+    group("KtHashSet", () {
+      testSet(
+        emptySet: <T>() => KtHashSet<T>.empty(),
+        mutableSetOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            KtHashSet<T>.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        mutableSetFrom: <T>([Iterable<T> iterable = const []]) =>
+            KtHashSet.from(iterable),
+      );
+    });
+    group("hashSet", () {
+      testSet(
+        emptySet: <T>() => hashSetOf<T>(),
+        mutableSetOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            hashSetOf(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        mutableSetFrom: <T>([Iterable<T> iterable = const []]) =>
+            hashSetFrom(iterable),
+      );
+    });
+
+    group("KtLinkedSet", () {
+      testSet(
+        emptySet: <T>() => KtLinkedSet<T>.empty(),
+        mutableSetOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            KtLinkedSet<T>.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        mutableSetFrom: <T>([Iterable<T> iterable = const []]) =>
+            KtLinkedSet.from(iterable),
+      );
+    });
+    group("linkedSet", () {
+      testSet(
+        emptySet: <T>() => linkedSetOf<T>(),
+        mutableSetOf: <T>(
+                [T arg0,
+                T arg1,
+                T arg2,
+                T arg3,
+                T arg4,
+                T arg5,
+                T arg6,
+                T arg7,
+                T arg8,
+                T arg9]) =>
+            linkedSetOf(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        mutableSetFrom: <T>([Iterable<T> iterable = const []]) =>
+            linkedSetFrom(iterable),
+      );
+    });
+  });
+}
+
+void testSet({
+  KtMutableSet<T> Function<T>() emptySet,
+  KtMutableSet<T> Function<T>(
+          [T arg0,
+          T arg1,
+          T arg2,
+          T arg3,
+          T arg4,
+          T arg5,
+          T arg6,
+          T arg7,
+          T arg8,
+          T arg9])
+      mutableSetOf,
+  KtMutableSet<T> Function<T>([Iterable<T> iterable]) mutableSetFrom,
+}) {
+  group("dart property", () {
+    test("dart property returns an empty list", () {
+      final dartList = emptySet<int>().dart;
+      expect(dartList.length, 0);
+    });
+
+    test("dart property returns an modifiable list", () {
+      final original = mutableSetOf<int>();
+      final dartList = original.dart;
+      dartList.add(1);
+      expect(original, mutableSetOf(1));
+      expect(dartList, {1});
+    });
+  });
+}

--- a/test/collection/set_mutable_test.dart
+++ b/test/collection/set_mutable_test.dart
@@ -4,38 +4,40 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mutableSet", () {
-    testMutableSet(
-      <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
-          mutableSetOf(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>(iterable) => mutableSetFrom(iterable),
-    );
-  });
-  group("KMutableSet", () {
-    testMutableSet(
-      <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
-          KtMutableSet.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>(iterable) => KtMutableSet.from(iterable),
-    );
-  });
-  group("KHashSet", () {
-    testMutableSet(
-      <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
-          KtHashSet.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>(iterable) => KtHashSet.from(iterable),
-      ordered: false,
-    );
-  });
-  group("KLinkedSet", () {
-    testMutableSet(
-      <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
-          KtLinkedSet.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>(iterable) => KtLinkedSet.from(iterable),
-    );
+  group("KtMutableSet", () {
+    group("mutableSet", () {
+      testMutableSet(
+        <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
+            mutableSetOf(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>(iterable) => mutableSetFrom(iterable),
+      );
+    });
+    group("KtMutableSet", () {
+      testMutableSet(
+        <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
+            KtMutableSet.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>(iterable) => KtMutableSet.from(iterable),
+      );
+    });
+    group("KtHashSet", () {
+      testMutableSet(
+        <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
+            KtHashSet.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>(iterable) => KtHashSet.from(iterable),
+        ordered: false,
+      );
+    });
+    group("KtLinkedSet", () {
+      testMutableSet(
+        <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
+            KtLinkedSet.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>(iterable) => KtLinkedSet.from(iterable),
+      );
+    });
   });
 }
 

--- a/test/collection/set_test.dart
+++ b/test/collection/set_test.dart
@@ -4,51 +4,54 @@ import "package:test/test.dart";
 import "../test/assert_dart.dart";
 
 void main() {
-  group("mutableSet", () {
-    testSet(
-      <T>() => mutableSetOf<T>(),
-      <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
-          mutableSetOf(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>(iterable) => mutableSetFrom(iterable),
-    );
-  });
   group("KtSet", () {
-    testSet(
-      <T>() => KtSet<T>.empty(),
-      <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
-          KtSet.of(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>(iterable) => KtSet.from(iterable),
-      mutable: false,
-    );
-  });
-  group("KMutableSet", () {
-    testSet(
-      <T>() => KtMutableSet<T>.empty(),
-      <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
-          KtMutableSet.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>(iterable) => KtMutableSet.from(iterable),
-    );
-  });
-  group("KHashSet", () {
-    testSet(
-      <T>() => KtHashSet<T>.empty(),
-      <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
-          KtHashSet.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>(iterable) => KtHashSet.from(iterable),
-      ordered: false,
-    );
-  });
-  group("KLinkedSet", () {
-    testSet(
-      <T>() => KtLinkedSet<T>.empty(),
-      <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
-          KtLinkedSet.of(
-              arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
-      <T>(iterable) => KtLinkedSet.from(iterable),
-    );
+    group("mutableSet", () {
+      testSet(
+        <T>() => mutableSetOf<T>(),
+        <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
+            mutableSetOf(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>(iterable) => mutableSetFrom(iterable),
+      );
+    });
+    group("KtSet", () {
+      testSet(
+        <T>() => KtSet<T>.empty(),
+        <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
+            KtSet.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>(iterable) => KtSet.from(iterable),
+        mutable: false,
+      );
+    });
+    group("KtMutableSet", () {
+      testSet(
+        <T>() => KtMutableSet<T>.empty(),
+        <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
+            KtMutableSet.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>(iterable) => KtMutableSet.from(iterable),
+      );
+    });
+    group("KtHashSet", () {
+      testSet(
+        <T>() => KtHashSet<T>.empty(),
+        <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
+            KtHashSet.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>(iterable) => KtHashSet.from(iterable),
+        ordered: false,
+      );
+    });
+    group("KtLinkedSet", () {
+      testSet(
+        <T>() => KtLinkedSet<T>.empty(),
+        <T>([arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9]) =>
+            KtLinkedSet.of(
+                arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+        <T>(iterable) => KtLinkedSet.from(iterable),
+      );
+    });
   });
 }
 
@@ -69,166 +72,164 @@ void testSet(
     KtSet<T> Function<T>(Iterable<T> iterable) setFrom,
     {bool ordered = true,
     bool mutable = true}) {
-  group("basic methods", () {
-    test("hashCode is 0", () {
-      expect(emptySet().hashCode, 0);
+  test("hashCode is 0", () {
+    expect(emptySet().hashCode, 0);
+  });
+
+  test("toString is []", () {
+    expect(emptySet().toString(), "[]");
+  });
+
+  test("empty iterator", () {
+    final iterator = setOf().iterator();
+    expect(iterator.hasNext(), isFalse);
+    expect(() => iterator.next(),
+        throwsA(const TypeMatcher<NoSuchElementException>()));
+  });
+
+  test("has no elements", () {
+    final set = setOf();
+    expect(set.size, equals(0));
+  });
+
+  test("contains nothing", () {
+    final set = setOf("a", "b", "c");
+    expect(set.contains("a"), isTrue);
+    expect(set.contains("b"), isTrue);
+    expect(set.contains("c"), isTrue);
+    expect(set.contains(null), isFalse);
+    expect(set.contains(""), isFalse);
+    expect(set.contains(null), isFalse);
+  });
+
+  test("empty iterator has no next", () {
+    final set = setOf();
+    final iterator = set.iterator();
+    expect(iterator.hasNext(), isFalse);
+    expect(() => iterator.next(),
+        throwsA(const TypeMatcher<NoSuchElementException>()));
+  });
+
+  test("iterator with 1 element has 1 next", () {
+    final set = setOf("a");
+    final iterator = set.iterator();
+    expect(iterator.hasNext(), isTrue);
+    expect(iterator.next(), equals("a"));
+
+    expect(iterator.hasNext(), isFalse);
+    expect(() => iterator.next(),
+        throwsA(const TypeMatcher<NoSuchElementException>()));
+  });
+
+  test("iterator with items", () {
+    final iterator = setOf(1, 2, 3).iterator();
+
+    expect(iterator.hasNext(), isTrue);
+    expect(iterator.next(), isNotNull);
+    expect(iterator.hasNext(), isTrue);
+    expect(iterator.next(), isNotNull);
+
+    expect(iterator.hasNext(), isTrue);
+    expect(iterator.next(), isNotNull);
+
+    expect(iterator.hasNext(), isFalse);
+    expect(() => iterator.next(),
+        throwsA(const TypeMatcher<NoSuchElementException>()));
+  });
+
+  test("is empty", () {
+    final set = setOf("asdf");
+
+    expect(set.isEmpty(), isFalse);
+    expect(set.isEmpty(), isFalse);
+  });
+
+  test("is equal to another set", () {
+    final set0 = setOf("a", "b", "c");
+    final set1 = setOf("b", "a", "c");
+    final set2 = setOf("a", "c");
+    final set3 = setOf();
+
+    expect(set0, equals(set1));
+    expect(set0.hashCode, equals(set1.hashCode));
+
+    expect(set0, isNot(equals(set2)));
+    expect(set0.hashCode, isNot(equals(set2.hashCode)));
+
+    expect(set0, isNot(equals(set3)));
+  });
+
+  test("is not equal to other types", () {
+    expect(setOf(1, 2, 3), isNot(equals(listOf(1, 2, 3))));
+    expect(setOf(1, 2, 3), isNot(equals("a, b, b")));
+    expect(setOf(1, 2, 3), isNot(equals(1)));
+  });
+
+  test("access dart set", () {
+    // ignore: deprecated_member_use_from_same_package
+    final Set<String> set = setOf<String>("a", "b", "c").set;
+    expect(set.length, 3);
+    expect(set, equals(Set.from(["a", "b", "c"])));
+  });
+
+  test("equals although differnt types (subtypes)", () {
+    expect(setOf<int>(1, 2, 3), setOf<num>(1, 2, 3));
+    expect(setOf<num>(1, 2, 3), setOf<int>(1, 2, 3));
+  });
+
+  if (mutable) {
+    test("emptySet, asSet allows mutation - empty", () {
+      final ktSet = emptySet<String>();
+      expect(ktSet.isEmpty(), isTrue);
+      final dartSet = ktSet.asSet();
+      dartSet.add("asdf");
+      expect(dartSet.length, 1);
+      expect(ktSet.size, 1);
     });
 
-    test("toString is []", () {
-      expect(emptySet().toString(), "[]");
+    test("empty mutable set, asSet allows mutation", () {
+      final ktSet = setOf<String>();
+      expect(ktSet.isEmpty(), isTrue);
+      final dartSet = ktSet.asSet();
+      dartSet.add("asdf");
+      expect(dartSet.length, 1);
+      expect(ktSet.size, 1);
     });
 
-    test("empty iterator", () {
-      final iterator = setOf().iterator();
-      expect(iterator.hasNext(), isFalse);
-      expect(() => iterator.next(),
-          throwsA(const TypeMatcher<NoSuchElementException>()));
+    test("mutable set, asSet allows mutation", () {
+      final ktSet = setOf("a");
+      final dartSet = ktSet.asSet();
+      dartSet.add("asdf");
+      expect(dartSet.length, 2);
+      expect(ktSet.size, 2);
+    });
+  } else {
+    test("emptySet, asSet doesn't allow mutation", () {
+      final ktSet = emptySet();
+      expect(ktSet.isEmpty(), isTrue);
+      final e =
+          catchException<UnsupportedError>(() => ktSet.asSet().add("asdf"));
+      expect(e.message, contains("unmodifiable"));
     });
 
-    test("has no elements", () {
-      final set = setOf();
-      expect(set.size, equals(0));
+    test("empty set, asSet doesn't allows mutation", () {
+      final ktSet = setOf<String>();
+      expect(ktSet.isEmpty(), isTrue);
+      final e =
+          catchException<UnsupportedError>(() => ktSet.asSet().add("asdf"));
+      expect(e.message, contains("unmodifiable"));
     });
 
-    test("contains nothing", () {
-      final set = setOf("a", "b", "c");
-      expect(set.contains("a"), isTrue);
-      expect(set.contains("b"), isTrue);
-      expect(set.contains("c"), isTrue);
-      expect(set.contains(null), isFalse);
-      expect(set.contains(""), isFalse);
-      expect(set.contains(null), isFalse);
+    test("set, asSet doesn't allows mutation", () {
+      final ktSet = setOf<String>("a");
+      final e =
+          catchException<UnsupportedError>(() => ktSet.asSet().add("asdf"));
+      expect(e.message, contains("unmodifiable"));
     });
+  }
 
-    test("empty iterator has no next", () {
-      final set = setOf();
-      final iterator = set.iterator();
-      expect(iterator.hasNext(), isFalse);
-      expect(() => iterator.next(),
-          throwsA(const TypeMatcher<NoSuchElementException>()));
-    });
-
-    test("iterator with 1 element has 1 next", () {
-      final set = setOf("a");
-      final iterator = set.iterator();
-      expect(iterator.hasNext(), isTrue);
-      expect(iterator.next(), equals("a"));
-
-      expect(iterator.hasNext(), isFalse);
-      expect(() => iterator.next(),
-          throwsA(const TypeMatcher<NoSuchElementException>()));
-    });
-
-    test("iterator with items", () {
-      final iterator = setOf(1, 2, 3).iterator();
-
-      expect(iterator.hasNext(), isTrue);
-      expect(iterator.next(), isNotNull);
-      expect(iterator.hasNext(), isTrue);
-      expect(iterator.next(), isNotNull);
-
-      expect(iterator.hasNext(), isTrue);
-      expect(iterator.next(), isNotNull);
-
-      expect(iterator.hasNext(), isFalse);
-      expect(() => iterator.next(),
-          throwsA(const TypeMatcher<NoSuchElementException>()));
-    });
-
-    test("is empty", () {
-      final set = setOf("asdf");
-
-      expect(set.isEmpty(), isFalse);
-      expect(set.isEmpty(), isFalse);
-    });
-
-    test("is equal to another set", () {
-      final set0 = setOf("a", "b", "c");
-      final set1 = setOf("b", "a", "c");
-      final set2 = setOf("a", "c");
-      final set3 = setOf();
-
-      expect(set0, equals(set1));
-      expect(set0.hashCode, equals(set1.hashCode));
-
-      expect(set0, isNot(equals(set2)));
-      expect(set0.hashCode, isNot(equals(set2.hashCode)));
-
-      expect(set0, isNot(equals(set3)));
-    });
-
-    test("is not equal to other types", () {
-      expect(setOf(1, 2, 3), isNot(equals(listOf(1, 2, 3))));
-      expect(setOf(1, 2, 3), isNot(equals("a, b, b")));
-      expect(setOf(1, 2, 3), isNot(equals(1)));
-    });
-
-    test("access dart set", () {
-      // ignore: deprecated_member_use_from_same_package
-      final Set<String> set = setOf<String>("a", "b", "c").set;
-      expect(set.length, 3);
-      expect(set, equals(Set.from(["a", "b", "c"])));
-    });
-
-    test("equals although differnt types (subtypes)", () {
-      expect(setOf<int>(1, 2, 3), setOf<num>(1, 2, 3));
-      expect(setOf<num>(1, 2, 3), setOf<int>(1, 2, 3));
-    });
-
-    if (mutable) {
-      test("emptySet, asSet allows mutation - empty", () {
-        final ktSet = emptySet<String>();
-        expect(ktSet.isEmpty(), isTrue);
-        final dartSet = ktSet.asSet();
-        dartSet.add("asdf");
-        expect(dartSet.length, 1);
-        expect(ktSet.size, 1);
-      });
-
-      test("empty mutable set, asSet allows mutation", () {
-        final ktSet = setOf<String>();
-        expect(ktSet.isEmpty(), isTrue);
-        final dartSet = ktSet.asSet();
-        dartSet.add("asdf");
-        expect(dartSet.length, 1);
-        expect(ktSet.size, 1);
-      });
-
-      test("mutable set, asSet allows mutation", () {
-        final ktSet = setOf("a");
-        final dartSet = ktSet.asSet();
-        dartSet.add("asdf");
-        expect(dartSet.length, 2);
-        expect(ktSet.size, 2);
-      });
-    } else {
-      test("emptySet, asSet doesn't allow mutation", () {
-        final ktSet = emptySet();
-        expect(ktSet.isEmpty(), isTrue);
-        final e =
-            catchException<UnsupportedError>(() => ktSet.asSet().add("asdf"));
-        expect(e.message, contains("unmodifiable"));
-      });
-
-      test("empty set, asSet doesn't allows mutation", () {
-        final ktSet = setOf<String>();
-        expect(ktSet.isEmpty(), isTrue);
-        final e =
-            catchException<UnsupportedError>(() => ktSet.asSet().add("asdf"));
-        expect(e.message, contains("unmodifiable"));
-      });
-
-      test("set, asSet doesn't allows mutation", () {
-        final ktSet = setOf<String>("a");
-        final e =
-            catchException<UnsupportedError>(() => ktSet.asSet().add("asdf"));
-        expect(e.message, contains("unmodifiable"));
-      });
-    }
-
-    test("setFrom requires non null iterable", () {
-      final e = catchException<ArgumentError>(() => setFrom(null));
-      expect(e.message, contains("elements can't be null"));
-    });
+  test("setFrom requires non null iterable", () {
+    final e = catchException<ArgumentError>(() => setFrom(null));
+    expect(e.message, contains("elements can't be null"));
   });
 }

--- a/test/collection/set_test.dart
+++ b/test/collection/set_test.dart
@@ -230,20 +230,5 @@ void testSet(
       final e = catchException<ArgumentError>(() => setFrom(null));
       expect(e.message, contains("elements can't be null"));
     });
-
-    group("orEmpty", () {
-      test("null -> empty set", () {
-        const KtSet<int> set = null;
-        expect(set.orEmpty(), isNotNull);
-        expect(set.orEmpty(), isA<KtSet<int>>());
-        expect(set.orEmpty().isEmpty(), isTrue);
-        expect(set.orEmpty().size, 0);
-      });
-      test("set -> just return the set", () {
-        final KtSet<int> set = setOf(1, 2, 3);
-        expect(set.orEmpty(), set);
-        expect(identical(set.orEmpty(), set), isTrue);
-      });
-    });
   });
 }

--- a/test/kt_dart_test.dart
+++ b/test/kt_dart_test.dart
@@ -23,6 +23,8 @@ import "collection/map_mutable_test.dart" as map_mutable_test;
 import "collection/map_test.dart" as map_test;
 import "collection/set_empty_test.dart" as set_empty_test;
 import "collection/set_extensions_test.dart" as set_extensions_test;
+import "collection/set_mutable_extensions_test.dart"
+    as set_mutable_extensions_test;
 import "collection/set_mutable_test.dart" as set_mutable_test;
 import "collection/set_test.dart" as set_test;
 import "collection/tuples_test.dart" as tuples_test;
@@ -53,6 +55,7 @@ void main() {
   map_test.main();
   set_empty_test.main();
   set_extensions_test.main();
+  set_mutable_extensions_test.main();
   set_mutable_test.main();
   set_test.main();
   tuples_test.main();

--- a/test/kt_dart_test.dart
+++ b/test/kt_dart_test.dart
@@ -22,6 +22,7 @@ import "collection/map_mutable_extensions_test.dart"
 import "collection/map_mutable_test.dart" as map_mutable_test;
 import "collection/map_test.dart" as map_test;
 import "collection/set_empty_test.dart" as set_empty_test;
+import "collection/set_extensions_test.dart" as set_extensions_test;
 import "collection/set_mutable_test.dart" as set_mutable_test;
 import "collection/set_test.dart" as set_test;
 import "collection/tuples_test.dart" as tuples_test;
@@ -51,6 +52,7 @@ void main() {
   map_mutable_test.main();
   map_test.main();
   set_empty_test.main();
+  set_extensions_test.main();
   set_mutable_test.main();
   set_test.main();
   tuples_test.main();


### PR DESCRIPTION
Analog to `.kt` but reverse

```dart
  // New: Converting dart collections to KtDart collections (mutable views)
  final KtMutableList<String> ktList = ["hey"].kt;
  final KtMutableSet<String> ktSet = {"hey"}.kt;
  final KtMutableMap<String, int> ktMap = {"hey": 1}.kt;

  // Converting KtDart collections to dart collections
  final List<String> dartList = KtList.of("hey").dart;
  final Set<String> dartSet = KtSet.of("hey").dart;
  final Map<String, int> dartMap = KtMap.from({"hey": 1}).dart;
```