### PR TITLE
Add KtIterable<num>.average()

### DIFF
--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -97,8 +97,8 @@ extension KtNumIterableExtension<T extends num> on KtIterable<T> {
     if (!iterator().hasNext()) return double.nan;
     while (i.hasNext()) {
       final next = i.next();
+      // nan values are ignored
       if (!next.isNaN) {
-        // nan values are ignored
         sum += next;
         count++;
       }
@@ -297,6 +297,7 @@ extension KtIterableExtensions<T> on KtIterable<T> {
     var count = 0;
     for (final element in iter) {
       final value = selector(element);
+      // nan values are ignored
       if (!value.isNaN) {
         sum += value;
         count++;

--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -88,6 +88,23 @@ extension KtNumIterableExtension<T extends num> on KtIterable<T> {
     }
     return min;
   }
+
+  /// Returns the average or `null` if there are no elements.
+  double average() {
+    var count = 0;
+    num sum = 0;
+    final i = iterator();
+    if (!iterator().hasNext()) return double.nan;
+    while (i.hasNext()) {
+      final next = i.next();
+      if (!next.isNaN) {
+        // nan values are ignored
+        sum += next;
+        count++;
+      }
+    }
+    return sum / count;
+  }
 }
 
 extension KtIntIterableExtension on KtIterable<int> {
@@ -279,10 +296,16 @@ extension KtIterableExtensions<T> on KtIterable<T> {
     num sum = 0.0;
     var count = 0;
     for (final element in iter) {
-      sum += selector(element);
-      ++count;
+      final value = selector(element);
+      if (!value.isNaN) {
+        sum += value;
+        count++;
+      }
     }
-    return count == 0 ? double.nan : sum / count;
+    if (count == 0) {
+      return double.nan;
+    }
+    return sum / count;
   }
 
   /// Splits this collection into a list of lists each not exceeding the given [size].

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -244,16 +244,49 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
   group("average", () {
     test("average of ints", () {
       final ints = iterableOf([1, 2, 3, 4]);
-      final result = ints.averageBy((it) => it);
+      final result = ints.average();
       expect(result, equals(2.5));
     });
     test("average of empty is NaN", () {
       final ints = emptyIterable<num>();
-      final result = ints.averageBy((it) => it);
+      final result = ints.average();
       expect(identical(result, double.nan), isTrue);
     });
     test("average of nums", () {
       final ints = iterableOf([1, 2.0, 3, 4]);
+      final result = ints.average();
+      expect(result, equals(2.5));
+    });
+    test("average of nums with NaN (nan is ignored)", () {
+      final ints = iterableOf([1, 2.0, double.nan, 3, double.nan, 4]);
+      final result = ints.average();
+      expect(result, equals(2.5));
+    });
+    test("average of nan only returns nan", () {
+      final ints = iterableOf([double.nan, double.nan, double.nan]);
+      final result = ints.average();
+      expect(identical(result, double.nan), isTrue);
+    });
+  });
+
+  group("averageBy", () {
+    test("averageBy of ints", () {
+      final ints = iterableOf([1, 2, 3, 4]);
+      final result = ints.averageBy((it) => it);
+      expect(result, equals(2.5));
+    });
+    test("averageBy of empty is NaN", () {
+      final ints = emptyIterable<num>();
+      final result = ints.averageBy((it) => it);
+      expect(identical(result, double.nan), isTrue);
+    });
+    test("averageBy of nums", () {
+      final ints = iterableOf([1, 2.0, 3, 4]);
+      final result = ints.averageBy((it) => it);
+      expect(result, equals(2.5));
+    });
+    test("averageBy of nums with NaN (nan is ignored)", () {
+      final ints = iterableOf([1, 2.0, double.nan, 3, double.nan, 4]);
       final result = ints.averageBy((it) => it);
       expect(result, equals(2.5));
     });
@@ -261,6 +294,11 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
       final list = emptyIterable<String>();
       final e = catchException<ArgumentError>(() => list.averageBy(null));
       expect(e.message, allOf(contains("null"), contains("selector")));
+    });
+    test("average of nan only returns nan", () {
+      final ints = iterableOf([double.nan, double.nan, double.nan]);
+      final result = ints.averageBy((it) => it);
+      expect(identical(result, double.nan), isTrue);
     });
   });
 


### PR DESCRIPTION
- Add `KtIterable<num>.average()`
- Changes behaviour of `averageBy()` to ignore `double.nan` values