### PR TITLE
Relax Comparable type restrictions

### DIFF
--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -1200,7 +1200,7 @@ extension KtIterableExtensions<T> on KtIterable<T> {
     final i = iterator();
     if (!iterator().hasNext()) return null;
     T minElement = i.next();
-    Comparable minValue = selector(minElement);
+    R minValue = selector(minElement);
     while (i.hasNext()) {
       final e = i.next();
       final v = selector(e);

--- a/lib/src/collection/kt_list_mutable.dart
+++ b/lib/src/collection/kt_list_mutable.dart
@@ -139,7 +139,7 @@ extension KtMutableListExtensions<T> on KtMutableList<T> {
   }
 
   /// Sorts elements in the list in-place according to natural sort order of the value returned by specified [selector] function.
-  void sortBy<R extends Comparable<R>>(R Function(T) selector) {
+  void sortBy<R extends Comparable>(R Function(T) selector) {
     assert(() {
       if (selector == null) throw ArgumentError("selector can't be null");
       return true;
@@ -150,7 +150,7 @@ extension KtMutableListExtensions<T> on KtMutableList<T> {
   }
 
   /// Sorts elements in the list in-place descending according to natural sort order of the value returned by specified [selector] function.
-  void sortByDescending<R extends Comparable<R>>(R Function(T) selector) {
+  void sortByDescending<R extends Comparable>(R Function(T) selector) {
     assert(() {
       if (selector == null) throw ArgumentError("selector can't be null");
       return true;

--- a/lib/src/collection/kt_map.dart
+++ b/lib/src/collection/kt_map.dart
@@ -418,7 +418,7 @@ extension KtMapExtensions<K, V> on KtMap<K, V> {
 
   /// Returns the first entry yielding the largest value of the given function or `null` if there are no entries.
   @nullable
-  KtMapEntry<K, V> maxBy<R extends Comparable<R>>(
+  KtMapEntry<K, V> maxBy<R extends Comparable>(
       R Function(KtMapEntry<K, V>) selector) {
     assert(() {
       if (selector == null) throw ArgumentError("selector can't be null");
@@ -470,7 +470,7 @@ extension KtMapExtensions<K, V> on KtMap<K, V> {
 
   /// Returns the first entry yielding the smallest value of the given function or `null` if there are no entries.
   @nullable
-  KtMapEntry<K, V> minBy<R extends Comparable<R>>(
+  KtMapEntry<K, V> minBy<R extends Comparable>(
       R Function(KtMapEntry<K, V>) selector) {
     assert(() {
       if (selector == null) throw ArgumentError("selector can't be null");

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -1649,18 +1649,25 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
   group("minBy", () {
     test("gets min value", () {
       final iterable = iterableOf(["1", "3", "2"]);
+      expect(iterable.minBy((it) => int.parse(it)), "1");
       expect(iterable.minBy((it) => num.parse(it)), "1");
     });
 
     test("empty iterable return null", () {
       final iterable = emptyIterable<int>();
+      expect(iterable.minBy((it) => it), null);
+      // with generic type
       expect(iterable.minBy<num>((it) => it), null);
     });
 
     test("minBy requires a non null selector", () {
       final e =
-          catchException<ArgumentError>(() => emptyIterable().minBy<num>(null));
+          catchException<ArgumentError>(() => emptyIterable().minBy(null));
       expect(e.message, allOf(contains("null"), contains("selector")));
+      // with generic type
+      final e1 =
+          catchException<ArgumentError>(() => emptyIterable().minBy<num>(null));
+      expect(e1.message, allOf(contains("null"), contains("selector")));
     });
   });
 

--- a/test/collection/list_mutable_extensions_test.dart
+++ b/test/collection/list_mutable_extensions_test.dart
@@ -149,10 +149,29 @@ void testList(
       expect(e.message, allOf(contains("null"), contains("selector")));
     });
 
+    test("sortBy works for ints", () {
+      // without specifying sortBy<num> as generic parameters
+      final result = mutableListOf(3, 4, 2, 1)..sortBy((it) => it);
+      expect(result, listOf(1, 2, 3, 4));
+
+      final result2 = mutableListOf(3, 4, 2, 1)..sortBy<num>((it) => it);
+      expect(result, result2);
+    });
+
     test("sortByDescending", () {
       final result = mutableListOf("paul", "john", "max", "lisa")
         ..sortByDescending(lastChar);
       expect(result, listOf("max", "john", "paul", "lisa"));
+    });
+
+    test("sortByDescending works for ints", () {
+      // without specifying sortByDescending<num> as generic parameters
+      final result = mutableListOf(3, 4, 2, 1)..sortByDescending((it) => it);
+      expect(result, listOf(4, 3, 2, 1));
+
+      final result2 = mutableListOf(3, 4, 2, 1)
+        ..sortByDescending<num>((it) => it);
+      expect(result, result2);
     });
 
     test("sortByDescending doesn't allow null as argument", () {

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -496,11 +496,14 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap,
   group("maxBy", () {
     test("gets max value", () {
       final map = mapFrom({"2": "Ivysaur", "1": "Bulbasaur"});
+      expect(map.maxBy((it) => int.parse(it.key)).value, "Ivysaur");
       expect(map.maxBy((it) => num.parse(it.key)).value, "Ivysaur");
     });
 
     test("empty iterable return null", () {
       final map = emptyMap<int, String>();
+      expect(map.maxBy((it) => it.key), null);
+      // with generic type
       expect(map.maxBy<num>((it) => it.key), null);
     });
 
@@ -508,6 +511,10 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap,
       final e =
           catchException<ArgumentError>(() => emptyMap().maxBy<num>(null));
       expect(e.message, allOf(contains("null"), contains("selector")));
+      // with generic type
+      final e1 =
+          catchException<ArgumentError>(() => emptyMap().maxBy<num>(null));
+      expect(e1.message, allOf(contains("null"), contains("selector")));
     });
   });
 
@@ -582,17 +589,16 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap,
   group("minBy", () {
     test("gets min value", () {
       final map = mapFrom({"2": "Ivysaur", "1": "Bulbasaur"});
-      expect(map.minBy((it) => num.parse(it.key)).value, "Bulbasaur");
+      expect(map.minBy((it) => int.parse(it.key)).value, "Bulbasaur");
     });
 
     test("empty iterable return null", () {
       final map = emptyMap<int, String>();
-      expect(map.minBy<num>((it) => it.key), null);
+      expect(map.minBy((it) => it.key), null);
     });
 
     test("minBy requires a non null selector", () {
-      final e =
-          catchException<ArgumentError>(() => emptyMap().minBy<num>(null));
+      final e = catchException<ArgumentError>(() => emptyMap().minBy(null));
       expect(e.message, allOf(contains("null"), contains("selector")));
     });
   });

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -590,16 +590,22 @@ void testMap(KtMap<K, V> Function<K, V>() emptyMap,
     test("gets min value", () {
       final map = mapFrom({"2": "Ivysaur", "1": "Bulbasaur"});
       expect(map.minBy((it) => int.parse(it.key)).value, "Bulbasaur");
+      expect(map.minBy((it) => num.parse(it.key)).value, "Bulbasaur");
     });
 
     test("empty iterable return null", () {
       final map = emptyMap<int, String>();
       expect(map.minBy((it) => it.key), null);
+      // with generic type
+      expect(map.minBy<int>((it) => it.key), null);
     });
 
     test("minBy requires a non null selector", () {
       final e = catchException<ArgumentError>(() => emptyMap().minBy(null));
       expect(e.message, allOf(contains("null"), contains("selector")));
+      // with generic type
+      final e1 = catchException<ArgumentError>(() => emptyMap().minBy(null));
+      expect(e1.message, allOf(contains("null"), contains("selector")));
     });
   });
 


### PR DESCRIPTION
Change `R extends Comparable<R>` to `R extends Comparable` for `minBy`, `maxBy`, `sortBy`, `sortByDescending`. This makes it easier when the type `R` is a `int`/`double` which doesn't implement `Comparable<int/double>` but `Comparable<num>`.