### PR TITLE
make constructors const where possible

### DIFF
--- a/lib/src/collection/impl/list_empty.dart
+++ b/lib/src/collection/impl/list_empty.dart
@@ -2,7 +2,7 @@ import "package:kt_dart/collection.dart";
 import "package:kt_dart/src/collection/impl/dart_iterable.dart";
 
 class EmptyList<T> extends Object implements KtList<T> {
-  EmptyList();
+  const EmptyList();
 
   @override
   List<T> get list => List.unmodifiable(const []);

--- a/lib/src/collection/impl/list_mutable.dart
+++ b/lib/src/collection/impl/list_mutable.dart
@@ -10,7 +10,7 @@ class DartMutableList<T> extends Object implements KtMutableList<T> {
         _list = List.from(iterable, growable: true),
         super();
 
-  DartMutableList.noCopy(List<T> list)
+  const DartMutableList.noCopy(List<T> list)
       : _list = list,
         super();
 

--- a/lib/src/collection/impl/map_empty.dart
+++ b/lib/src/collection/impl/map_empty.dart
@@ -1,7 +1,7 @@
 import "package:kt_dart/collection.dart";
 
 class EmptyMap<K, V> extends Object implements KtMap<K, V> {
-  EmptyMap();
+  const EmptyMap();
 
   @override
   Iterable<KtMapEntry<K, V>> get iter => List.unmodifiable(const []);

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -11,7 +11,7 @@ class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
   /// Doesn't copy the incoming list which is more efficient but risks accidental modification of the incoming map.
   ///
   /// Use with care!
-  DartMutableMap.noCopy(Map<K, V> map)
+  const DartMutableMap.noCopy(Map<K, V> map)
       : _map = map,
         super();
 

--- a/lib/src/collection/impl/set_empty.dart
+++ b/lib/src/collection/impl/set_empty.dart
@@ -3,7 +3,7 @@ import "package:kt_dart/src/collection/impl/dart_iterable.dart";
 import "package:kt_dart/src/collection/impl/dart_unmodifiable_set_view.dart";
 
 class EmptySet<T> extends Object implements KtSet<T> {
-  EmptySet();
+  const EmptySet();
 
   @override
   Set<T> get set => UnmodifiableSetView(<T>{});

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -9,7 +9,7 @@ class DartMutableSet<T> extends Object implements KtMutableSet<T> {
   /// Doesn't copy the incoming list which is more efficient but risks accidental modification of the incoming map.
   ///
   /// Use with care!
-  DartMutableSet.noCopy(Set<T> set)
+  const DartMutableSet.noCopy(Set<T> set)
       : _set = set,
         super();
 

--- a/lib/src/collection/kt_list.dart
+++ b/lib/src/collection/kt_list.dart
@@ -8,7 +8,7 @@ import "package:kt_dart/src/util/arguments.dart";
 /// @param [T] the type of elements contained in the list. The list is covariant on its element type.
 abstract class KtList<T> implements KtCollection<T> {
   /// Returns an empty read-only list.
-  factory KtList.empty() = EmptyList<T>;
+  const factory KtList.empty() = EmptyList<T>;
 
   /// Returns a new read-only list based on [elements].
   factory KtList.from([@nonNull Iterable<T> elements = const []]) {

--- a/lib/src/collection/kt_map.dart
+++ b/lib/src/collection/kt_map.dart
@@ -11,7 +11,7 @@ import "package:kt_dart/src/util/errors.dart";
 ///          can accept key as a parameter (of [containsKey] for example) and return it in [keys] set.
 /// @param V the type of map values. The map is covariant on its value type.
 abstract class KtMap<K, V> {
-  factory KtMap.empty() = EmptyMap<K, V>;
+  const factory KtMap.empty() = EmptyMap<K, V>;
 
   factory KtMap.from([@nonNull Map<K, V> map = const {}]) {
     assert(() {

--- a/lib/src/collection/kt_set.dart
+++ b/lib/src/collection/kt_set.dart
@@ -9,7 +9,7 @@ import "package:kt_dart/src/util/arguments.dart";
 /// @param E the type of elements contained in the set. The set is covariant on its element type.
 abstract class KtSet<T> implements KtCollection<T> {
   /// Returns an empty read-only set.
-  factory KtSet.empty() = EmptySet<T>;
+  const factory KtSet.empty() = EmptySet<T>;
 
   /// Returns a new read-only set based on [elements].
   factory KtSet.from([@nonNull Iterable<T> elements = const []]) {


### PR DESCRIPTION
fixes #125 

This pull request will allow empty lists, sets, and maps to be used as defaults in optional parameters
