### PR TITLE
Add plus(Element)/minus(Element) to Set which returns Set

### DIFF
--- a/lib/src/collection/kt_set.dart
+++ b/lib/src/collection/kt_set.dart
@@ -99,6 +99,58 @@ extension KtSetExtension<T> on KtSet<T> {
   /// This method can be used to interop between the dart:collection and the
   /// kt.dart world.
   Set<T> get dart => asSet();
+
+  /// Returns a list containing all elements of the original collection except the elements contained in the given [elements] collection.
+  KtSet<T> minus(KtIterable<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
+    final result = toMutableSet();
+    result.removeAll(elements);
+    return result;
+  }
+
+  /// Returns a list containing all elements of the original collection except the elements contained in the given [elements] collection.
+  KtSet<T> operator -(KtIterable<T> elements) => minus(elements);
+
+  /// Returns a list containing all elements of the original collection without the first occurrence of the given [element].
+  KtSet<T> minusElement(T element) {
+    final result = KtMutableSet<T>.of();
+    var removed = false;
+    filterTo(result, (it) {
+      if (!removed && it == element) {
+        removed = true;
+        return false;
+      } else {
+        return true;
+      }
+    });
+    return result;
+  }
+
+  /// Returns a list containing all elements of the original collection and then all elements of the given [elements] collection.
+  KtSet<T> plus(KtIterable<T> elements) {
+    assert(() {
+      if (elements == null) throw ArgumentError("elements can't be null");
+      return true;
+    }());
+    final result = KtMutableSet<T>.of();
+    result.addAll(asIterable());
+    result.addAll(elements);
+    return result;
+  }
+
+  /// Returns a list containing all elements of the original collection and then all elements of the given [elements] collection.
+  KtSet<T> operator +(KtIterable<T> elements) => plus(elements);
+
+  /// Returns a list containing all elements of the original collection and then the given [element].
+  KtSet<T> plusElement(T element) {
+    final result = KtMutableSet<T>.of();
+    result.addAll(asIterable());
+    result.add(element);
+    return result;
+  }
 }
 
 extension NullableKtSetExtensions<T> on KtSet<T> /*?*/ {

--- a/test/collection/set_extensions_test.dart
+++ b/test/collection/set_extensions_test.dart
@@ -78,4 +78,59 @@ void testSet(
       expect(identical(set.orEmpty(), set), isTrue);
     });
   });
+
+  group("minus", () {
+    test("remove iterable", () {
+      final result =
+          setOf("paul", "john", "max", "lisa").minus(setOf("max", "john"));
+      expect(result, setOf("paul", "lisa"));
+    });
+    test("infix", () {
+      final result = setOf("paul", "john", "max", "lisa") - setOf("max");
+      expect(result.toSet(), setOf("paul", "john", "lisa"));
+    });
+    test("empty gets returned empty", () {
+      final result = emptySet<String>() - setOf("max");
+      expect(result.toList(), emptyList());
+    });
+    test("minus doesn't allow null as elements", () {
+      final iterable = emptySet<String>();
+      final e = catchException<ArgumentError>(() => iterable.minus(null));
+      expect(e.message, allOf(contains("null"), contains("elements")));
+    });
+  });
+
+  group("minusElement", () {
+    test("remove one item", () {
+      final result = setOf("paul", "john", "max", "lisa").minusElement("max");
+      expect(result.toSet(), setOf("paul", "john", "lisa"));
+    });
+  });
+
+  group("plus", () {
+    test("concat two iterables", () {
+      final result = setOf(1, 2, 3).plus(setOf(4, 5, 6));
+      expect(result, setOf(1, 2, 3, 4, 5, 6));
+    });
+    test("infix", () {
+      final result = setOf(1, 2, 3) + setOf(4, 5, 6);
+      expect(result, setOf(1, 2, 3, 4, 5, 6));
+    });
+    test("plus doesn't allow null as elements", () {
+      final iterable = emptySet<String>();
+      final e = catchException<ArgumentError>(() => iterable.plus(null));
+      expect(e.message, allOf(contains("null"), contains("elements")));
+    });
+  });
+
+  group("plusElement", () {
+    test("concat item", () {
+      final result = setOf(1, 2, 3).plusElement(5);
+      expect(result, setOf(1, 2, 3, 5));
+    });
+    test("element can be null", () {
+      final result = setOf(1, 2, 3).plusElement(null);
+      expect(result, setOf(1, 2, 3, null));
+    });
+  });
 }


### PR DESCRIPTION
Adds the following extensions

- `KtSet<T>.minus(KtIterable<T> elements): KtSet<T>()`
- `KtSet<T>.operator -(KtIterable<T> elements): KtSet<T>()`
- `KtSet<T>.minusElement(T element): KtSet<T>()`
- `KtSet<T>.plus(KtIterable<T> elements): KtSet<T>()`
- `KtSet<T>.operator +(KtIterable<T> elements): KtSet<T>()`
- `KtSet<T>.plusElement(T element): KtSet<T>()`

Fixes #123 