### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.8.0
+
+New `package:kt_dart/standard.dart` library containing Kotlins loved standard extensions
+- [#120](https://github.com/passsy/kt.dart/pull/120) Standard extensions `let`, `also`, `takeIf` and `takeUnless`
+- [#120](https://github.com/passsy/kt.dart/pull/120) `TODO([String message])` top-level function which throws `NotImplementedException`
+- [#120](https://github.com/passsy/kt.dart/pull/120) `repeat(int times, void Function(int) action)` top-level function
+
+More cool updates
+- [#124](https://github.com/passsy/kt.dart/pull/124) `KtList.of` and `KtSet.of` now allow `null` as parameters. Same for `listOf` and `setOf`
+- [#131](https://github.com/passsy/kt.dart/pull/131) Chain Comparators with the new `thenBy` and `thenByDescending` functions.
+- [#126](https://github.com/passsy/kt.dart/pull/126) Allow const `.empty()` constructors for `KtList`, `KtMap` and `KtSet` (Thanks @TimWhiting)
+- [#127](https://github.com/passsy/kt.dart/pull/127) `plus`, `minus` operator overrides for `KtSet`, returning `KtSet` and not `KtList` as the `KtIterable` operators do
+
 ## 0.8.0-dev.1
 
 - [#124](https://github.com/passsy/kt.dart/pull/124) `KtList.of` and `KtSet.of` now allow `null` as parameters. Same for `listOf` and `setOf`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kt_dart
 description: This project is a port of kotlin-stdlib for Dart/Flutter projects. It includes collections (KtList, KtMap, KtSet) with 150+ methods as well as other useful packages.
-version: 0.8.0-dev.1
+version: 0.8.0
 homepage: https://github.com/passsy/kt.dart
 
 environment:


### PR DESCRIPTION
New `package:kt_dart/standard.dart` library containing Kotlins loved standard extensions
- [#120](https://github.com/passsy/kt.dart/pull/120) Standard extensions `let`, `also`, `takeIf` and `takeUnless`
- [#120](https://github.com/passsy/kt.dart/pull/120) `TODO([String message])` top-level function which throws `NotImplementedException`
- [#120](https://github.com/passsy/kt.dart/pull/120) `repeat(int times, void Function(int) action)` top-level function

More cool updates
- [#124](https://github.com/passsy/kt.dart/pull/124) `KtList.of` and `KtSet.of` now allow `null` as parameters. Same for `listOf` and `setOf`
- [#131](https://github.com/passsy/kt.dart/pull/131) Chain Comparators with the new `thenBy` and `thenByDescending` functions.
- [#126](https://github.com/passsy/kt.dart/pull/126) Allow const `.empty()` constructors for `KtList`, `KtMap` and `KtSet` (Thanks @TimWhiting)
- [#127](https://github.com/passsy/kt.dart/pull/127) `plus`, `minus` operator overrides for `KtSet`, returning `KtSet` and not `KtList` as the `KtIterable` operators do