### PR TITLE
Performance Improvement to KtSet.contains

### DIFF
--- a/lib/src/collection/impl/dart_unmodifiable_set_view.dart
+++ b/lib/src/collection/impl/dart_unmodifiable_set_view.dart
@@ -24,6 +24,9 @@ class UnmodifiableSetView<E> extends Object
   Set<T> cast<T>() => _set.cast<T>();
 
   @override
+  bool contains(Object? element) => _set.contains(element);
+
+  @override
   bool containsAll(Iterable<Object?> other) => _set.containsAll(other);
 
   @override


### PR DESCRIPTION
Hello there from a related project called [Fast Immutable Collections (FIC)][fic]. In it, we created a [`benchmark_app`][benchmark_app] to compare our collections to the main ones and other notable packages &mdash; currently kt.dart and [built_collection][built_collection]. The project is not finished yet and neither is the benchmark app itself, so please don't take what you find there as our final say.

Anyway, we stumbled upon a peculiar result when running `contains` benchmarks for sets. All of the collections were giving similar results with the exception of KtDart's:

![WithIteratorMixin](https://user-images.githubusercontent.com/11823725/103679524-b0b5e780-4f63-11eb-9ff6-ac8a7b8b2027.PNG)

After a little bit of digging I found out that KtDart uses `IterableMixin` inside its `UnmodifiableSetView`. This lets the view implement the `Set` interface with way less work. However, it uses `Iterable` implementations of methods and not necessarily what you would like specifically for `Set`s. A `contains` for a `Set` and a `contains` for an `Iterable` would have require different implementations optimizations. For example, [the `contains` for `IterableMixin` has an internal loop which slows down `UnmodifiableSetView`][iterable_mixin_loop]:

```dart
bool contains(Object? element) {
  for (E e in this) {
    if (e == element) return true;
  }
  return false;
}
```

In the end, fixing this is apparently not that difficult. What I did was simply override `contains` to use the `_set`'s `contains` instead:

```dart
@override
bool contains(Object? element) => _set.contains(element);
```

This is the result after adding that bit of code:

![PatchedContains](https://user-images.githubusercontent.com/11823725/103680775-6d5c7880-4f65-11eb-8daf-d8c649742649.png)

That said, I think it would be even easier and less code to use `SetMixin` instead, which is also what we ended up using in FIC. But I don't know the other requirements of the project, so I'll leave it for others to fill in the gaps.


[benchmark_app]: https://github.com/marcglasberg/fast_immutable_collections/tree/master/benchmark/benchmark_app
[built_collection]: https://pub.dev/packages/built_collection
[iterable_mixin_loop]: https://github.com/dart-lang/sdk/blob/7c148d029de32590a8d0d332bf807d25929f080e/sdk/lib/collection/iterable.dart#L36-L41
[fic]: https://github.com/marcglasberg/fast_immutable_collections