### PR TITLE
Let sumBy accept num/int/double

### DIFF
--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -1291,21 +1291,18 @@ extension KtIterableExtensions<T> on KtIterable<T> {
   }
 
   /// Returns the sum of all values produced by [selector] function applied to each element in the collection.
-  int sumBy(int Function(T) selector) {
-    int sum = 0;
+  R sumBy<R extends num>(R Function(T) selector) {
+    var sum = R == double ? 0.0 : 0;
     for (final element in iter) {
       sum += selector(element);
     }
-    return sum;
+    return sum as R;
   }
 
   /// Returns the sum of all values produced by [selector] function applied to each element in the collection.
+  @Deprecated("Use sumBy")
   double sumByDouble(double Function(T) selector) {
-    double sum = 0.0;
-    for (final element in iter) {
-      sum += selector(element);
-    }
-    return sum;
+    return sumBy(selector);
   }
 
   /// Returns a list containing first [n] elements.

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -1614,12 +1614,25 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
   });
 
   group("sumBy", () {
-    test("double", () {
+    test("int", () {
       expect(iterableOf([1, 2, 3]).sumBy((i) => i * 2), 12);
     });
 
-    test("factor 1.5", () {
+    test("double", () {
+      expect(iterableOf([1, 2, 3]).sumBy((i) => i * 1.5), 9.0);
+
+      // ignore: deprecated_member_use_from_same_package
       expect(iterableOf([1, 2, 3]).sumByDouble((i) => i * 1.5), 9.0);
+    });
+
+    test("double as num", () {
+      const num factor = 1.5;
+      expect(iterableOf([1, 2, 3]).sumBy((i) => i * factor), 9.0);
+    });
+
+    test("double as num", () {
+      const num factor = 2;
+      expect(iterableOf([1, 2, 3]).sumBy((i) => i * factor), 12);
     });
   });
 


### PR DESCRIPTION
Similar to https://github.com/leisim/dartx/pull/127

Deprecated `sumByDouble` because `sumBy` can now always be used 