### PR TITLE
List of groupBy are now true KtList not KtMutableList, allowing furhter processing

### DIFF
--- a/lib/src/collection/impl/iterator.dart
+++ b/lib/src/collection/impl/iterator.dart
@@ -1,5 +1,4 @@
 import "package:kt_dart/collection.dart";
-import "package:kt_dart/src/collection/kt_iterator_mutable.dart";
 
 class InterOpKIterator<T> implements KtIterator<T> {
   InterOpKIterator(this.iterator) : _hasNext = iterator.moveNext() {

--- a/lib/src/collection/impl/map_empty.dart
+++ b/lib/src/collection/impl/map_empty.dart
@@ -25,7 +25,7 @@ class EmptyMap<K, V> extends Object implements KtMap<K, V> {
   V? get(K key) => null;
 
   @override
-  V? getOrDefault(K key, V defaultValue) => defaultValue;
+  V getOrDefault(K key, V defaultValue) => defaultValue;
 
   @override
   bool isEmpty() => true;

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -41,7 +41,7 @@ class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
   V? operator [](K key) => get(key);
 
   @override
-  V? getOrDefault(K key, V defaultValue) => _map[key] ?? defaultValue;
+  V getOrDefault(K key, V defaultValue) => _map[key] ?? defaultValue;
 
   @override
   bool isEmpty() => _map.isEmpty;

--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -696,7 +696,7 @@ extension KtIterableExtensions<T> on KtIterable<T> {
   /// The returned map preserves the entry iteration order of the keys produced from the original collection.
   KtMap<K, KtList<T>> groupBy<K>(K Function(T) keySelector) {
     final groups = groupByTo(linkedMapFrom<K, KtMutableList<T>>(), keySelector);
-    return groups;
+    return groups.mapValues((pair) => pair.value);
   }
 
   /// Groups values returned by the [valueTransform] function applied to each element of the original collection
@@ -706,9 +706,9 @@ extension KtIterableExtensions<T> on KtIterable<T> {
   /// The returned map preserves the entry iteration order of the keys produced from the original collection.
   KtMap<K, KtList<V>> groupByTransform<K, V>(
       K Function(T) keySelector, V Function(T) valueTransform) {
-    final groups = groupByToTransform(
-        linkedMapFrom<K, KtMutableList<V>>(), keySelector, valueTransform);
-    return groups;
+    final KtLinkedMap<K, KtMutableList<V>> groups =
+        groupByToTransform(linkedMapFrom(), keySelector, valueTransform);
+    return groups.mapValues((it) => it.value);
   }
 
   /// Groups elements of the original collection by the key returned by the given [keySelector] function

--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -1,7 +1,6 @@
 import "dart:math" as math;
 
 import "package:kt_dart/collection.dart";
-import "package:kt_dart/src/collection/comparisons.dart";
 import "package:kt_dart/src/util/errors.dart";
 
 /// Classes that inherit from this interface can be represented as a sequence of elements that can

--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -694,8 +694,14 @@ extension KtIterableExtensions<T> on KtIterable<T> {
   ///
   /// The returned map preserves the entry iteration order of the keys produced from the original collection.
   KtMap<K, KtList<T>> groupBy<K>(K Function(T) keySelector) {
-    final groups = groupByTo(linkedMapFrom<K, KtMutableList<T>>(), keySelector);
-    return groups.mapValues((pair) => pair.value);
+    final groups = linkedMapFrom<K, KtList<T>>();
+    for (final element in iter) {
+      final key = keySelector(element);
+      final list = KtMutableMapExtensions(groups)
+          .getOrPut(key, () => mutableListOf<T>()) as KtMutableList<T>;
+      list.add(element);
+    }
+    return groups;
   }
 
   /// Groups values returned by the [valueTransform] function applied to each element of the original collection
@@ -705,9 +711,14 @@ extension KtIterableExtensions<T> on KtIterable<T> {
   /// The returned map preserves the entry iteration order of the keys produced from the original collection.
   KtMap<K, KtList<V>> groupByTransform<K, V>(
       K Function(T) keySelector, V Function(T) valueTransform) {
-    final KtLinkedMap<K, KtMutableList<V>> groups =
-        groupByToTransform(linkedMapFrom(), keySelector, valueTransform);
-    return groups.mapValues((it) => it.value);
+    final groups = linkedMapFrom<K, KtList<V>>();
+    for (final element in iter) {
+      final key = keySelector(element);
+      final list = KtMutableMapExtensions(groups)
+          .getOrPut(key, () => mutableListOf<V>()) as KtMutableList<V>;
+      list.add(valueTransform(element));
+    }
+    return groups;
   }
 
   /// Groups elements of the original collection by the key returned by the given [keySelector] function

--- a/lib/src/collection/kt_map.dart
+++ b/lib/src/collection/kt_map.dart
@@ -51,7 +51,7 @@ abstract class KtMap<K, V> {
   V? operator [](K key);
 
   /// Returns the value corresponding to the given [key], or [defaultValue] if such a key is not present in the map.
-  V? getOrDefault(K key, V defaultValue);
+  V getOrDefault(K key, V defaultValue);
 
   // Views
   /// Returns a read-only [KtSet] of all keys in this map.

--- a/test/collection/dart_unmodifiable_set_view_test.dart
+++ b/test/collection/dart_unmodifiable_set_view_test.dart
@@ -1,5 +1,5 @@
-import "package:test/test.dart";
 import "package:kt_dart/collection.dart";
+import "package:test/test.dart";
 
 import "../test/assert_dart.dart";
 

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -842,6 +842,21 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
   });
 
   group("groupBy", () {
+    test("basic generic return type 100% matches", () {
+      final iterable = iterableOf(["paul", "peter", "john", "lisa"]);
+      final grouped = iterable.groupBy((it) => it.length);
+      // Fixes https://github.com/passsy/kt.dart/issues/139
+      expect(grouped.runtimeType.toString(), contains("<int, KtList<String>"));
+    });
+
+    test("valuetransform generic return type 100% matches", () {
+      final iterable = iterableOf(["paul", "peter", "john", "lisa"]);
+      final grouped = iterable.groupByTransform(
+          (it) => it.length, (it) => it.toUpperCase());
+      // Fixes https://github.com/passsy/kt.dart/issues/139
+      expect(grouped.runtimeType.toString(), contains("<int, KtList<String>"));
+    });
+
     if (ordered) {
       test("basic", () {
         final iterable = iterableOf(["paul", "peter", "john", "lisa"]);

--- a/test/collection/map_extensions_test.dart
+++ b/test/collection/map_extensions_test.dart
@@ -709,7 +709,7 @@ class ThirdPartyMap<K, V> implements KtMap<K, V> {
   V? operator [](K key) => get(key);
 
   @override
-  V? getOrDefault(K key, V defaultValue) => _map[key] ?? defaultValue;
+  V getOrDefault(K key, V defaultValue) => _map[key] ?? defaultValue;
 
   @override
   bool isEmpty() => _map.isEmpty;

--- a/test/issues/all_issues.dart
+++ b/test/issues/all_issues.dart
@@ -1,5 +1,7 @@
 import "issue_111.dart" as issue_111;
+import "issue_139.dart" as issue_139;
 
 void main() {
   issue_111.main();
+  issue_139.main();
 }

--- a/test/issues/issue_139.dart
+++ b/test/issues/issue_139.dart
@@ -4,23 +4,25 @@ import "package:test/test.dart";
 void main() {
   // https://github.com/passsy/kt.dart/issues/139
   test("issue #139", () {
-    var usd = Currency(1, "USD");
-    var inr = Currency(2, "INR");
-    KtList<Currency> currency = listOf(usd, inr);
-    KtList<CurrencyConversionData> conversion =
+    final usd = Currency(1, "USD");
+    final inr = Currency(2, "INR");
+    final KtList<Currency> currency = listOf(usd, inr);
+    final KtList<CurrencyConversionData> conversion =
         listOf(CurrencyConversionData(1, 2));
-    KtMap<Currency, KtList<Currency>> conversions =
+    final KtMap<Currency, KtList<Currency>> conversions =
         _toCurrencyMap(conversion, currency);
 
     // CRASH HERE (type 'EmptyList<Currency>' is not a subtype of type 'KtMutableList<Currency>' of 'defaultValue')
-    final result = conversions.getOrDefault(Currency(3, "EUR"), KtList.empty());
+    final result =
+        conversions.getOrDefault(Currency(3, "EUR"), const KtList.empty());
     expect(result, emptyList());
   });
 }
 
 KtMap<Currency, KtList<Currency>> _toCurrencyMap(
     KtList<CurrencyConversionData> conversion, KtList<Currency> currency) {
-  KtMap<int, Currency> currencyMap = currency.associateBy((cur) => cur.id);
+  final KtMap<int, Currency> currencyMap =
+      currency.associateBy((cur) => cur.id);
   return conversion.groupByTransform(
     (conv) => currencyMap.get(conv.fromRef)!,
     (conv) => currencyMap.get(conv.toRef)!,

--- a/test/issues/issue_139.dart
+++ b/test/issues/issue_139.dart
@@ -1,0 +1,42 @@
+import "package:kt_dart/kt.dart";
+import "package:test/test.dart";
+
+void main() {
+  // https://github.com/passsy/kt.dart/issues/139
+  test("issue #139", () {
+    var usd = Currency(1, "USD");
+    var inr = Currency(2, "INR");
+    KtList<Currency> currency = listOf(usd, inr);
+    KtList<CurrencyConversionData> conversion =
+        listOf(CurrencyConversionData(1, 2));
+    KtMap<Currency, KtList<Currency>> conversions =
+        _toCurrencyMap(conversion, currency);
+
+    // CRASH HERE (type 'EmptyList<Currency>' is not a subtype of type 'KtMutableList<Currency>' of 'defaultValue')
+    final result = conversions.getOrDefault(Currency(3, "EUR"), KtList.empty());
+    expect(result, emptyList());
+  });
+}
+
+KtMap<Currency, KtList<Currency>> _toCurrencyMap(
+    KtList<CurrencyConversionData> conversion, KtList<Currency> currency) {
+  KtMap<int, Currency> currencyMap = currency.associateBy((cur) => cur.id);
+  return conversion.groupByTransform(
+    (conv) => currencyMap.get(conv.fromRef)!,
+    (conv) => currencyMap.get(conv.toRef)!,
+  );
+}
+
+class Currency {
+  final int id;
+  final String ticker;
+
+  Currency(this.id, this.ticker);
+}
+
+class CurrencyConversionData {
+  final int fromRef;
+  final int toRef;
+
+  CurrencyConversionData(this.fromRef, this.toRef);
+}

--- a/test/standard/standard_test.dart
+++ b/test/standard/standard_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:kt_dart/kt.dart';
+import 'package:test/test.dart';
 
 import '../test/assert_dart.dart';
 


### PR DESCRIPTION
Fixes #139

Also:
- Change `KtMap.getOrDefault<T>` to return `T` instead of `T?`
- Fix CI