### PR TITLE
Cast result of requireNoNulls to be non-null

### DIFF
--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -16,12 +16,6 @@ abstract class KtIterable<T> {
 
 extension KtComparableIterableExtension<T extends Comparable<T>>
     on KtIterable<T> {
-  /// Returns a dart:core [Iterable]
-  ///
-  /// This method can be used to interop between the dart:collection and the
-  /// kt.dart world.
-  Iterable<T> get dart => iter;
-
   /// Returns the largest element or `null` if there are no elements.
   T? max() {
     final i = iterator();
@@ -125,6 +119,12 @@ extension KtDoubleIterableExtension on KtIterable<double> {
 }
 
 extension KtIterableExtensions<T> on KtIterable<T> {
+  /// Returns a dart:core [Iterable]
+  ///
+  /// This method can be used to interop between the dart:collection and the
+  /// kt.dart world.
+  Iterable<T> get dart => iter;
+
   /// Returns `true` if all elements match the given [predicate].
   bool all(bool Function(T element) predicate) {
     if (this is KtCollection && (this as KtCollection).isEmpty()) return true;

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -314,6 +314,15 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
       final Iterable<String> iterable = emptyIterable<String>().dart;
       expect(iterable.length, 0);
     });
+
+    test('dart work on all objects', () {
+      // there was once a bug where it only worked for Comparable<T>
+      iterableOf(<dynamic>[]).dart;
+      iterableOf(<Object>[]).dart;
+      iterableOf(<num>[]).dart;
+      iterableOf(<RegExp>[]).dart;
+      iterableOf(<Future>[]).dart;
+    });
   });
 
   group("drop", () {
@@ -1022,6 +1031,27 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
       final b = iterableOf(["julie", "richard", "john", "lisa"]);
       final result = a.intersect(b);
       expect(result, setOf("john", "lisa"));
+    });
+  });
+
+  group("iter", () {
+    test("iterate using a for loop", () {
+      final items = KtMutableList<String>.empty();
+      for (final String s in iterableOf(["a", "b", "c"]).iter) {
+        items.add(s);
+      }
+      expect(items.size, 3);
+      if (ordered) {
+        expect(items, listOf("a", "b", "c"));
+      }
+    });
+
+    test('iter work on all objects', () {
+      iterableOf(<dynamic>[]).iter;
+      iterableOf(<Object>[]).iter;
+      iterableOf(<num>[]).iter;
+      iterableOf(<RegExp>[]).iter;
+      iterableOf(<Future>[]).iter;
     });
   });
 

--- a/test/collection/list_test.dart
+++ b/test/collection/list_test.dart
@@ -1,4 +1,5 @@
 import "package:kt_dart/collection.dart";
+import 'package:kt_dart/src/util/arguments.dart';
 import "package:test/test.dart";
 
 import "../test/assert_dart.dart";
@@ -13,6 +14,37 @@ void main() {
     group("mutableList", () {
       testList(mutableListOf, mutableListOf, mutableListFrom);
       testList(<T>() => KtMutableList.empty(), mutableListOf, mutableListFrom);
+    });
+    group("CastKtList", () {
+      testList(
+        <T>() => KtList<T>.empty().cast(),
+        <T>(
+                [dynamic arg0,
+                dynamic arg1,
+                dynamic arg2,
+                dynamic arg3,
+                dynamic arg4,
+                dynamic arg5,
+                dynamic arg6,
+                dynamic arg7,
+                dynamic arg8,
+                dynamic arg9]) =>
+            KtList<dynamic>.of(
+                    arg0 as T? ?? defaultArgument,
+                    arg1 as T? ?? defaultArgument,
+                    arg2 as T? ?? defaultArgument,
+                    arg3 as T? ?? defaultArgument,
+                    arg4 as T? ?? defaultArgument,
+                    arg5 as T? ?? defaultArgument,
+                    arg6 as T? ?? defaultArgument,
+                    arg7 as T? ?? defaultArgument,
+                    arg8 as T? ?? defaultArgument,
+                    arg9 as T? ?? defaultArgument)
+                .cast(),
+        <T>([Iterable<T> iterable = const []]) =>
+            KtList<T>.from(iterable).cast(),
+        mutable: false,
+      );
     });
   });
 
@@ -73,6 +105,15 @@ void testList(
       expect(list.contains(null), isFalse);
       expect(list.contains(""), isFalse);
       expect(list.contains(null), isFalse);
+    });
+
+    test('containsAll', () {
+      final list = listOf<String?>("a", "b", "c");
+      expect(list.containsAll(listOf("a", "b")), isTrue);
+      expect(list.containsAll(listOf("a", "c")), isTrue);
+      expect(list.containsAll(listOf()), isTrue);
+      expect(list.containsAll(listOf("x")), isFalse);
+      expect(list.containsAll(listOf("a", "x")), isFalse);
     });
 
     test("iterator with 1 element has 1 next", () {

--- a/test/collection/set_test.dart
+++ b/test/collection/set_test.dart
@@ -93,6 +93,15 @@ void testSet(
     expect(set.contains(null), isFalse);
   });
 
+  test('containsAll', () {
+    final list = listOf<String?>("a", "b", "c");
+    expect(list.containsAll(listOf("a", "b")), isTrue);
+    expect(list.containsAll(listOf("a", "c")), isTrue);
+    expect(list.containsAll(listOf()), isTrue);
+    expect(list.containsAll(listOf("x")), isFalse);
+    expect(list.containsAll(listOf("a", "x")), isFalse);
+  });
+
   test("empty iterator has no next", () {
     final set = setOf();
     final iterator = set.iterator();


### PR DESCRIPTION
- `KtIterable<T?>.requireNonNulls()` now returns `KtIterable<T>`. Same for `KtList`
- New `KtIterable<T>.cast<R>()`allows lazily casting of `KtIterable`. This is useful to map between `T?` and `T` without iterating over all elements using `.map`. Also works for `KtList`
- Fixes `.dart` to work for all `KtIterable<T>`. Was accidentally registered for `KtIterable<T extends Comparable<T>>` only