### PR TITLE
Add onEachIndexed and make onEach chainable

### DIFF
--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -1516,6 +1516,7 @@ extension ChainableKtIterableExtensions<T> on KtIterable<T> {
     return this;
   }
 }
+
 class _MovingSubList<T> {
   _MovingSubList(this.list);
 

--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -1109,21 +1109,6 @@ extension KtIterableExtensions<T> on KtIterable<T> {
     return true;
   }
 
-  /// Performs the given [action] on each element. Use with cascade syntax to return self.
-  ///
-  ///       (listOf("a", "b", "c")
-  ///          ..onEach(print))
-  ///          .map((it) => it.toUpperCase())
-  ///          .getOrNull(0); // prints: a
-  ///
-  // ignore: comment_references
-  /// Without the cascade syntax (..) [KtListExtensions.getOrNull] wouldn't be available.
-  void onEach(void Function(T) action) {
-    for (final element in iter) {
-      action(element);
-    }
-  }
-
   /// Splits the original collection into pair of lists,
   /// where *first* list contains elements for which [predicate] yielded `true`,
   /// while *second* list contains elements for which [predicate] yielded `false`.
@@ -1504,6 +1489,33 @@ extension KtIterableExtensions<T> on KtIterable<T> {
   }
 }
 
+// Should be <T, C extends KtIterable<T>> on C but then T resolves to dynamic
+extension ChainableKtIterableExtensions<T> on KtIterable<T> {
+  /// Performs the given [action] on each element. Use with cascade syntax to return self.
+  ///
+  /// final result = listOf("a", "b", "c")
+  ///     .onEach(print)
+  ///     .map((it) => it.toUpperCase())
+  ///     .getOrNull(0);
+  /// // result: A
+  ///
+  /// Without the cascade syntax (..) [KtListExtensions.getOrNull] wouldn't be available.
+  KtIterable<T> onEach(void Function(T item) action) {
+    for (final element in iter) {
+      action(element);
+    }
+    return this;
+  }
+
+  /// Performs the given action on each element, providing sequential index with the element, and returns the collection itself afterwards.
+  KtIterable<T> onEachIndexed(void Function(int index, T item) action) {
+    var index = 0;
+    for (final item in iter) {
+      action(index++, item);
+    }
+    return this;
+  }
+}
 class _MovingSubList<T> {
   _MovingSubList(this.list);
 

--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -1489,7 +1489,8 @@ extension KtIterableExtensions<T> on KtIterable<T> {
   }
 }
 
-// Should be <T, C extends KtIterable<T>> on C but then T resolves to dynamic
+// TODO: Should be <T, C extends KtIterable<T>> on C but then T resolves to dynamic
+// https://github.com/dart-lang/sdk/issues/46117
 extension ChainableKtIterableExtensions<T> on KtIterable<T> {
   /// Performs the given [action] on each element. Use with cascade syntax to return self.
   ///

--- a/lib/src/collection/kt_list.dart
+++ b/lib/src/collection/kt_list.dart
@@ -374,3 +374,31 @@ extension NullableKtListExtensions<T> on KtList<T>? {
   /// Returns this [KtList] if it's not `null` and the empty list otherwise.
   KtList<T> orEmpty() => this ?? KtList<T>.empty();
 }
+
+// TODO remove in favor of ChainableKtIterableExtensions once https://github.com/dart-lang/sdk/issues/46117 is resolved
+extension ChainableKtListExtensions<T> on KtList<T> {
+  /// Performs the given [action] on each element. Use with cascade syntax to return self.
+  ///
+  /// final result = listOf("a", "b", "c")
+  ///     .onEach(print)
+  ///     .map((it) => it.toUpperCase())
+  ///     .getOrNull(0);
+  /// // result: A
+  ///
+  /// Without the cascade syntax (..) [KtListExtensions.getOrNull] wouldn't be available.
+  KtList<T> onEach(void Function(T item) action) {
+    for (final element in iter) {
+      action(element);
+    }
+    return this;
+  }
+
+  /// Performs the given action on each element, providing sequential index with the element, and returns the collection itself afterwards.
+  KtList<T> onEachIndexed(void Function(int index, T item) action) {
+    var index = 0;
+    for (final item in iter) {
+      action(index++, item);
+    }
+    return this;
+  }
+}

--- a/lib/src/collection/kt_set.dart
+++ b/lib/src/collection/kt_set.dart
@@ -152,3 +152,31 @@ extension NullableKtSetExtensions<T> on KtSet<T>? {
   /// Returns this [KtSet] if it's not `null` and the empty set otherwise.
   KtSet<T> orEmpty() => this ?? KtSet<T>.empty();
 }
+
+// TODO remove in favor of ChainableKtIterableExtensions once https://github.com/dart-lang/sdk/issues/46117 is resolved
+extension ChainableKtSetExtensions<T> on KtSet<T> {
+  /// Performs the given [action] on each element. Use with cascade syntax to return self.
+  ///
+  /// final result = setOf("a", "b", "c")
+  ///     .onEach(print)
+  ///     .map((it) => it.toUpperCase())
+  ///     .getOrNull(0);
+  /// // result: A
+  ///
+  /// Without the cascade syntax (..) [KtListExtensions.getOrNull] wouldn't be available.
+  KtSet<T> onEach(void Function(T item) action) {
+    for (final element in iter) {
+      action(element);
+    }
+    return this;
+  }
+
+  /// Performs the given action on each element, providing sequential index with the element, and returns the collection itself afterwards.
+  KtSet<T> onEachIndexed(void Function(int index, T item) action) {
+    var index = 0;
+    for (final item in iter) {
+      action(index++, item);
+    }
+    return this;
+  }
+}

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -1414,6 +1414,45 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
       iterable.onEach((it) => it.add(0));
       expect(iterable.map((it) => it.last).toList(), listOf(0, 0, 0));
     });
+
+    test("chainable", () {
+      final list = KtMutableList.empty();
+      final result = listOf("a", "b", "c")
+          .onEach((it) => list.add(it))
+          .map((it) => it.toUpperCase())
+          .getOrNull(0); // prints: A
+      expect(result, "A");
+      expect(list, listOf("a", "b", "c"));
+    });
+  });
+
+  group("onEachIndexed", () {
+    test("pairs", () {
+      final indexes = KtMutableList<int>.empty();
+      final items = KtMutableList<int>.empty();
+      final iterable = iterableOf([1, 2, 3]);
+      iterable.onEachIndexed((index, item) {
+        indexes.add(index);
+        items.add(item);
+      });
+      expect(indexes, listOf(0, 1, 2));
+      if (ordered) {
+        expect(items, iterable.toList());
+      }
+    });
+
+    test("chainable", () {
+      final list = KtMutableList.empty();
+      final result = listOf("a", "b", "c")
+          .onEachIndexed((index, it) {
+            list.add(index);
+            list.add(it);
+          })
+          .map((it) => it.toUpperCase())
+          .getOrNull(0); // prints: A
+      expect(result, "A");
+      expect(list, listOf(0, "a", 1, "b", 2, "c"));
+    });
   });
 
   group("partition", () {


### PR DESCRIPTION
Add `onEachIndexed` analog to `onEach` but with an index.

`onEach` and `onEachIndexed` don't return `void` but the collection they iterate on. 