### PR TITLE
Exit with exit code of test run

### DIFF
--- a/tool/run_coverage_locally.sh
+++ b/tool/run_coverage_locally.sh
@@ -19,6 +19,9 @@ dart \
     --enable-asserts \
     test/kt_dart_test.dart
 
+TEST_EXIT_CODE=$?
+echo "$TEST_EXIT_CODE"
+
 pub global run coverage:format_coverage \
     --lcov \
     --in=out/coverage/coverage.json \
@@ -32,3 +35,5 @@ if type genhtml >/dev/null 2>&1; then
 else
  echo "genhtml not installed, can't generate html coverage output"
 fi
+
+exit $TEST_EXIT_CODE


### PR DESCRIPTION
While reviewing #167 I noticed that failing test did not fail the CI step. This is now fixed
