### PR TITLE
Update pub.dev links to GitHub

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: kt_dart
 description: This project is a port of kotlin-stdlib for Dart/Flutter projects. It includes collections (KtList, KtMap, KtSet) with 150+ methods as well as other useful packages.
 version: 0.10.0
-homepage: https://github.com/passsy/kt.dart
+repository: https://github.com/passsy/kt.dart
+issue_tracker: https://github.com/passsy/kt.dart/issues
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).