### PR TITLE
new methods firstNotNullOf and firstNotNullOfOrNull for KtList

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,17 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
+
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 
 # Conventional directory for build outputs
 build/
 out/
+coverage/
 
 # Directory created by dartdoc
 doc/api/
 
 .idea
+.vscode

--- a/lib/src/collection/kt_iterable.dart
+++ b/lib/src/collection/kt_iterable.dart
@@ -597,6 +597,27 @@ extension KtIterableExtensions<T> on KtIterable<T> {
     }
   }
 
+  /// Returns the first non-null value after applying the given [transform]
+  /// function, throwing a [NoSuchElementException] exception if there is no
+  /// such value.
+  R firstNotNullOf<R>(R? Function(T?) transform) {
+    final R? element = firstNotNullOfOrNull(transform);
+    if (element != null) {
+      return element;
+    } else {
+      throw const NoSuchElementException(
+        "No element of the collection was transformed to a non-null value.",
+      );
+    }
+  }
+
+  /// Returns the first non-null value after applying the given [transform]
+  /// function; `null` will be returned if there is no such value.
+  R? firstNotNullOfOrNull<R>(R? Function(T?) transform) {
+    final KtList<R> mappedList = mapNotNull(transform);
+    return mappedList.firstOrNull();
+  }
+
   /// Returns the first element (matching [predicate] when provided), or `null` if the collection is empty.
   T? firstOrNull([bool Function(T)? predicate]) {
     if (predicate == null) {

--- a/test/collection/iterable_extensions_test.dart
+++ b/test/collection/iterable_extensions_test.dart
@@ -806,6 +806,56 @@ void testIterable(KtIterable<T> Function<T>() emptyIterable,
     });
   });
 
+  group("firstNotNullOf", () {
+    test("should return the first element, which is not null", () {
+      final list = listOf("a", "a", "c");
+      expect(list.firstNotNullOf((i) => i == "a" ? i : null), "a");
+    });
+
+    test("should return the third element, which is the first not null", () {
+      final list = listOf("a", "a", "c");
+      expect(list.firstNotNullOf((i) => i == "c" ? i : null), "c");
+    });
+
+    test("should throw if the list contains only null elements", () {
+      final list = listOf("a", "a", "a");
+      expect(
+        () => list.firstNotNullOf((i) => i == "c" ? i : null),
+        throwsA(const TypeMatcher<NoSuchElementException>()),
+      );
+    });
+
+    test("should throw if the list is empty", () {
+      final list = listOf();
+      expect(
+        () => list.firstNotNullOf((i) => i == "a" ? i : null),
+        throwsA(const TypeMatcher<NoSuchElementException>()),
+      );
+    });
+  });
+
+  group("firstNotNullOfOrNull", () {
+    test("should return the first element, which is not null", () {
+      final list = listOf("a", "a", "c");
+      expect(list.firstNotNullOfOrNull((i) => i == "a" ? i : null), "a");
+    });
+
+    test("should return the third element, which is the first not null", () {
+      final list = listOf("a", "a", "c");
+      expect(list.firstNotNullOfOrNull((i) => i == "c" ? i : null), "c");
+    });
+
+    test("should return null if the list contains only null elements", () {
+      final list = listOf("a", "a", "a");
+      expect(list.firstNotNullOfOrNull((i) => i == "c" ? i : null), null);
+    });
+
+    test("should return null if the list is empty", () {
+      final list = listOf();
+      expect(list.firstNotNullOfOrNull((i) => i == "a" ? i : null), null);
+    });
+  });
+
   group("firstOrNull", () {
     if (ordered) {
       test("get first element", () {


### PR DESCRIPTION
Closes [#162](https://github.com/passsy/kt.dart/issues/162)

`firstNotNullOf` and `firstNotNullOfOrNull` [doc reference](https://kotlinlang.org/docs/whatsnew15.html#new-collections-function-firstnotnullof)