### PR TITLE
runningFold method alongside tests

### DIFF
--- a/lib/src/collection/kt_collection.dart
+++ b/lib/src/collection/kt_collection.dart
@@ -56,6 +56,17 @@ extension KtCollectionExtensions<T> on KtCollection<T> {
     return sum as R;
   }
 
+  /// Returns a list containing the results of applying the given [operation]
+  /// function to each element in the original collection and the previous
+  /// accumulator value.
+  KtCollection<R> runningFold<R>(R initial, R Function(R, T) operation) {
+    var accumulator = initial;
+    return KtMutableList<R>.from(iter
+        .map((element) => accumulator = operation(accumulator, element))
+        .toList())
+      ..addAt(0, initial);
+  }
+
   /// Returns a [KtMutableList] filled with all elements of this collection.
   KtMutableList<T> toMutableList() => KtMutableList<T>.from(iter);
 }

--- a/test/collection/collection_test.dart
+++ b/test/collection/collection_test.dart
@@ -205,6 +205,18 @@ void testCollection(KtCollection<T> Function<T>() emptyCollection,
     });
   });
 
+  group("runningFold", () {
+    test("running folds a string list", () {
+      final strings = listOf<String>("a", "b", "c", "d");
+      final runningFolded =
+          strings.runningFold<String>("s", (acc, string) => acc + string);
+      expect(
+        runningFolded,
+        KtMutableList.of("s", "sa", "sab", "sabc", "sabcd"),
+      );
+    });
+  });
+
   group("toString", () {
     if (ordered) {
       test("default string representation", () {


### PR DESCRIPTION
Hi,

I have added the runningFold method as requested in #151. Should the method stay in KtCollectionExtension?

The performed test is the same as the example present in Kotlin's documentation.

Reference: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.sequences/running-fold.html