### PR TITLE
Implement InterOpKtListIterator.remove() and _MutableSetIterator.remove()

### DIFF
--- a/lib/src/collection/impl/iterator.dart
+++ b/lib/src/collection/impl/iterator.dart
@@ -51,7 +51,7 @@ class InterOpKtListIterator<T>
 
   @override
   void remove() {
-    _ensureHasLastReturnedElement();   
+    _ensureHasLastReturnedElement();
     _list.removeAt(_lastRet);
     _cursor = _lastRet;
     _lastRet = -1;
@@ -85,7 +85,7 @@ class InterOpKtListIterator<T>
     _ensureHasLastReturnedElement();
     _list.replaceRange(_lastRet, _lastRet + 1, [element]);
   }
-  
+
   void _ensureHasLastReturnedElement() {
     if (_lastRet < 0) {
       throw const IndexOutOfBoundsException(

--- a/lib/src/collection/impl/iterator.dart
+++ b/lib/src/collection/impl/iterator.dart
@@ -51,12 +51,10 @@ class InterOpKtListIterator<T>
 
   @override
   void remove() {
-    // removing from list is wrong because is is a copy of the original list.
-    // remove should modify the underlying list, not the copy
-    // see how kotlin solved this:
-    // https://github.com/JetBrains/kotlin/blob/ba6da7c40a6cc502508faf6e04fa105b96bc7777/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt
-    throw UnimplementedError(
-        "remove() in not yet implemented. Please vote for https://github.com/passsy/dart_kollection/issues/5 for prioritization");
+    _ensureHasLastReturnedElement();   
+    _list.removeAt(_lastRet);
+    _cursor = _lastRet;
+    _lastRet = -1;
   }
 
   @override
@@ -84,10 +82,14 @@ class InterOpKtListIterator<T>
 
   @override
   void set(T element) {
+    _ensureHasLastReturnedElement();
+    _list.replaceRange(_lastRet, _lastRet + 1, [element]);
+  }
+  
+  void _ensureHasLastReturnedElement() {
     if (_lastRet < 0) {
       throw const IndexOutOfBoundsException(
           "illegal cursor state -1. next() or previous() not called");
     }
-    _list.replaceRange(_lastRet, _lastRet + 1, [element]);
   }
 }

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -157,32 +157,32 @@ class _MutableEntry<K, V> implements KtMutableMapEntry<K, V> {
 }
 
 class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
-  _MapIterator(this.map) : entriesIterator = map.entries.iterator();
+  _MapIterator(this.map) : _entriesIterator = map.entries.iterator();
 
   // used to distinguish `null` (a valid key) from no key
   static final Object _noKeyReturned = Object();
 
   final DartMutableMap<K, V> map;
-  final KtMutableIterator<KtMutableMapEntry<K, V>> entriesIterator;
-  Object? lastReturnedKey = _noKeyReturned;
+  final KtMutableIterator<KtMutableMapEntry<K, V>> _entriesIterator;
+  Object? _lastReturnedKey = _noKeyReturned;
 
   @override
-  bool hasNext() => entriesIterator.hasNext();
+  bool hasNext() => _entriesIterator.hasNext();
 
   @override
   KtMutableMapEntry<K, V> next() {
-    final nextEntry = entriesIterator.next();
-    lastReturnedKey = nextEntry.key;
+    final nextEntry = _entriesIterator.next();
+    _lastReturnedKey = nextEntry.key;
     return nextEntry;
   }
 
   @override
   void remove() {
-    final lastReturnedKey = this.lastReturnedKey;
+    final lastReturnedKey = this._lastReturnedKey;
     if (lastReturnedKey == _noKeyReturned) {
       throw StateError("next() must be called before remove()");
     }
     map.remove(lastReturnedKey as K);
-    this.lastReturnedKey = _noKeyReturned;
+    this._lastReturnedKey = _noKeyReturned;
   }
 }

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -183,6 +183,6 @@ class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
       throw StateError("next() must be called before remove()");
     }
     map.remove(lastReturnedKey as K);
-    this._lastReturnedKey = _noKey;
+    _lastReturnedKey = _noKey;
   }
 }

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -160,7 +160,7 @@ class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
   _MapIterator(this.map) : entriesIterator = map.entries.iterator();
 
   final DartMutableMap<K, V> map;
-  final KtMutableIterator <KtMutableMapEntry<K, V>> entriesIterator;
+  final KtMutableIterator<KtMutableMapEntry<K, V>> entriesIterator;
   K? lastReturnedKey;
 
   @override

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -176,8 +176,9 @@ class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
   @override
   void remove() {
     final lastReturnedKey = this.lastReturnedKey;
-    if (lastReturnedKey == null)
+    if (lastReturnedKey == null) {
       throw StateError("next() must be called before remove()");
+    }
     map.remove(lastReturnedKey);
     this.lastReturnedKey = null;
   }

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -4,7 +4,7 @@ import "package:kt_dart/src/util/hash.dart";
 class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
   DartMutableMap([Map<K, V> map = const {}])
       :
-        // copy list to prevent external modification
+  // copy list to prevent external modification
         _map = Map<K, V>.from(map),
         super();
 
@@ -31,8 +31,9 @@ class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
   bool containsValue(V value) => _map.containsValue(value);
 
   @override
-  KtMutableSet<KtMutableMapEntry<K, V>> get entries => linkedSetFrom(
-      _map.entries.map((entry) => _MutableEntry.from(entry, this)));
+  KtMutableSet<KtMutableMapEntry<K, V>> get entries =>
+      linkedSetFrom(
+          _map.entries.map((entry) => _MutableEntry.from(entry, this)));
 
   @override
   V? get(K key) => _map[key];
@@ -102,10 +103,14 @@ class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
   }
 
   @override
-  int get hashCode => hashObjects(_map.keys
-      .map((key) => hash2(key.hashCode, _map[key].hashCode))
-      .toList(growable: false)
-    ..sort());
+  KtMutableIterator<KtMutableMapEntry<K, V>> iterator() => _MapIterator(this);
+
+  @override
+  int get hashCode =>
+      hashObjects(_map.keys
+          .map((key) => hash2(key.hashCode, _map[key].hashCode))
+          .toList(growable: false)
+        ..sort());
 
   @override
   String toString() {
@@ -123,10 +128,8 @@ class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
 class _MutableEntry<K, V> implements KtMutableMapEntry<K, V> {
   _MutableEntry(this._key, this._value, this._parent);
 
-  factory _MutableEntry.from(
-    MapEntry<K, V> entry,
-    DartMutableMap<K, V> parent,
-  ) =>
+  factory _MutableEntry.from(MapEntry<K, V> entry,
+      DartMutableMap<K, V> parent,) =>
       _MutableEntry(entry.key, entry.value, parent);
 
   K _key;
@@ -151,4 +154,30 @@ class _MutableEntry<K, V> implements KtMutableMapEntry<K, V> {
 
   @override
   KtPair<K, V> toPair() => KtPair(_key, _value);
+}
+
+class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
+  _MapIterator(this.map) : entriesIterator = map.entries.iterator();
+
+  final DartMutableMap<K, V> map;
+  final KtMutableIterator <KtMutableMapEntry<K, V>> entriesIterator;
+  K? lastReturnedKey;
+
+  @override
+  bool hasNext() => entriesIterator.hasNext();
+
+  @override
+  KtMutableMapEntry<K, V> next() {
+    final nextEntry = entriesIterator.next();
+    lastReturnedKey = nextEntry.key;
+    return nextEntry;
+  }
+
+  @override
+  void remove() {
+    final lastReturnedKey = this.lastReturnedKey;
+    if (lastReturnedKey == null) throw StateError("next() must be called before remove()");
+    map.remove(lastReturnedKey);
+    this.lastReturnedKey = null;
+  }
 }

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -4,7 +4,7 @@ import "package:kt_dart/src/util/hash.dart";
 class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
   DartMutableMap([Map<K, V> map = const {}])
       :
-  // copy list to prevent external modification
+        // copy list to prevent external modification
         _map = Map<K, V>.from(map),
         super();
 
@@ -31,9 +31,8 @@ class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
   bool containsValue(V value) => _map.containsValue(value);
 
   @override
-  KtMutableSet<KtMutableMapEntry<K, V>> get entries =>
-      linkedSetFrom(
-          _map.entries.map((entry) => _MutableEntry.from(entry, this)));
+  KtMutableSet<KtMutableMapEntry<K, V>> get entries => linkedSetFrom(
+      _map.entries.map((entry) => _MutableEntry.from(entry, this)));
 
   @override
   V? get(K key) => _map[key];
@@ -106,11 +105,10 @@ class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
   KtMutableIterator<KtMutableMapEntry<K, V>> iterator() => _MapIterator(this);
 
   @override
-  int get hashCode =>
-      hashObjects(_map.keys
-          .map((key) => hash2(key.hashCode, _map[key].hashCode))
-          .toList(growable: false)
-        ..sort());
+  int get hashCode => hashObjects(_map.keys
+      .map((key) => hash2(key.hashCode, _map[key].hashCode))
+      .toList(growable: false)
+    ..sort());
 
   @override
   String toString() {
@@ -128,8 +126,10 @@ class DartMutableMap<K, V> extends Object implements KtMutableMap<K, V> {
 class _MutableEntry<K, V> implements KtMutableMapEntry<K, V> {
   _MutableEntry(this._key, this._value, this._parent);
 
-  factory _MutableEntry.from(MapEntry<K, V> entry,
-      DartMutableMap<K, V> parent,) =>
+  factory _MutableEntry.from(
+    MapEntry<K, V> entry,
+    DartMutableMap<K, V> parent,
+  ) =>
       _MutableEntry(entry.key, entry.value, parent);
 
   K _key;
@@ -176,7 +176,8 @@ class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
   @override
   void remove() {
     final lastReturnedKey = this.lastReturnedKey;
-    if (lastReturnedKey == null) throw StateError("next() must be called before remove()");
+    if (lastReturnedKey == null)
+      throw StateError("next() must be called before remove()");
     map.remove(lastReturnedKey);
     this.lastReturnedKey = null;
   }

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -160,11 +160,11 @@ class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
   _MapIterator(this.map) : _entriesIterator = map.entries.iterator();
 
   // used to distinguish `null` (a valid key) from no key
-  static final Object _noKeyReturned = Object();
+  static final Object _noKey = Object();
 
   final DartMutableMap<K, V> map;
   final KtMutableIterator<KtMutableMapEntry<K, V>> _entriesIterator;
-  Object? _lastReturnedKey = _noKeyReturned;
+  Object? _lastReturnedKey = _noKey;
 
   @override
   bool hasNext() => _entriesIterator.hasNext();
@@ -178,11 +178,11 @@ class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
 
   @override
   void remove() {
-    final lastReturnedKey = this._lastReturnedKey;
-    if (lastReturnedKey == _noKeyReturned) {
+    final lastReturnedKey = _lastReturnedKey;
+    if (lastReturnedKey == _noKey) {
       throw StateError("next() must be called before remove()");
     }
     map.remove(lastReturnedKey as K);
-    this._lastReturnedKey = _noKeyReturned;
+    this._lastReturnedKey = _noKey;
   }
 }

--- a/lib/src/collection/impl/map_mutable.dart
+++ b/lib/src/collection/impl/map_mutable.dart
@@ -159,9 +159,12 @@ class _MutableEntry<K, V> implements KtMutableMapEntry<K, V> {
 class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
   _MapIterator(this.map) : entriesIterator = map.entries.iterator();
 
+  // used to distinguish `null` (a valid key) from no key
+  static final Object _noKeyReturned = Object();
+
   final DartMutableMap<K, V> map;
   final KtMutableIterator<KtMutableMapEntry<K, V>> entriesIterator;
-  K? lastReturnedKey;
+  Object? lastReturnedKey = _noKeyReturned;
 
   @override
   bool hasNext() => entriesIterator.hasNext();
@@ -176,10 +179,10 @@ class _MapIterator<K, V> implements KtMutableIterator<KtMutableMapEntry<K, V>> {
   @override
   void remove() {
     final lastReturnedKey = this.lastReturnedKey;
-    if (lastReturnedKey == null) {
+    if (lastReturnedKey == _noKeyReturned) {
       throw StateError("next() must be called before remove()");
     }
-    map.remove(lastReturnedKey);
-    this.lastReturnedKey = null;
+    map.remove(lastReturnedKey as K);
+    this.lastReturnedKey = _noKeyReturned;
   }
 }

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -136,7 +136,8 @@ class _MutableSetIterator<T> extends KtMutableIterator<T> {
   @override
   void remove() {
     final lastReturned = this.lastReturned;
-    if (lastReturned == null) throw StateError('remove() must be called after next()');
+    if (lastReturned == null)
+      throw StateError('remove() must be called after next()');
     set.remove(lastReturned);
     this.lastReturned = null;
   }

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -105,16 +105,16 @@ class DartMutableSet<T> extends Object implements KtMutableSet<T> {
 class _MutableSetIterator<T> extends KtMutableIterator<T> {
   _MutableSetIterator(this.set)
       : _iterator = set.iter.iterator,
-        lastReturned = null {
+        _lastReturned = null {
     _hasNext = _iterator.moveNext();
     if (_hasNext) {
-      nextValue = _iterator.current;
+      _nextValue = _iterator.current;
     }
   }
 
   final Iterator<T> _iterator;
-  T? nextValue;
-  T? lastReturned;
+  T? _nextValue;
+  T? _lastReturned;
   bool _hasNext = false;
   final KtMutableSet<T> set;
 
@@ -124,22 +124,22 @@ class _MutableSetIterator<T> extends KtMutableIterator<T> {
   @override
   T next() {
     if (!_hasNext) throw const NoSuchElementException();
-    final e = nextValue;
+    final e = _nextValue;
     _hasNext = _iterator.moveNext();
     if (_hasNext) {
-      nextValue = _iterator.current;
+      _nextValue = _iterator.current;
     }
-    lastReturned = e;
+    _lastReturned = e;
     return e as T;
   }
 
   @override
   void remove() {
-    final lastReturned = this.lastReturned;
+    final lastReturned = this._lastReturned;
     if (lastReturned == null) {
       throw StateError('remove() must be called after next()');
     }
     set.remove(lastReturned);
-    this.lastReturned = null;
+    this._lastReturned = null;
   }
 }

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -106,17 +106,19 @@ class _MutableSetIterator<T> extends KtMutableIterator<T> {
   _MutableSetIterator(this.set)
       :
         // copy to set to avoid concurrent modification
-        _iterator = set.toSet().iter.iterator,
-        _lastReturned = null {
+        _iterator = set.toSet().iter.iterator {
     _hasNext = _iterator.moveNext();
     if (_hasNext) {
       _nextValue = _iterator.current;
     }
   }
 
+  // used to distinguish `null` from no value returned
+  static final Object _noValue = Object();
+
   final Iterator<T> _iterator;
   T? _nextValue;
-  T? _lastReturned;
+  Object? _lastReturned = _noValue;
   bool _hasNext = false;
   final KtMutableSet<T> set;
 
@@ -137,11 +139,11 @@ class _MutableSetIterator<T> extends KtMutableIterator<T> {
 
   @override
   void remove() {
-    final lastReturned = this._lastReturned;
-    if (lastReturned == null) {
+    final lastReturned = _lastReturned;
+    if (lastReturned == _noValue) {
       throw StateError('remove() must be called after next()');
     }
-    set.remove(lastReturned);
-    this._lastReturned = null;
+    set.remove(lastReturned as T);
+    this._lastReturned = _noValue;
   }
 }

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -136,8 +136,9 @@ class _MutableSetIterator<T> extends KtMutableIterator<T> {
   @override
   void remove() {
     final lastReturned = this.lastReturned;
-    if (lastReturned == null)
+    if (lastReturned == null) {
       throw StateError('remove() must be called after next()');
+    }
     set.remove(lastReturned);
     this.lastReturned = null;
   }

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -104,7 +104,9 @@ class DartMutableSet<T> extends Object implements KtMutableSet<T> {
 
 class _MutableSetIterator<T> extends KtMutableIterator<T> {
   _MutableSetIterator(this.set)
-      : _iterator = set.iter.iterator,
+      :
+        // copy to set to avoid concurrent modification
+        _iterator = set.toSet().iter.iterator,
         _lastReturned = null {
     _hasNext = _iterator.moveNext();
     if (_hasNext) {

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -144,6 +144,6 @@ class _MutableSetIterator<T> extends KtMutableIterator<T> {
       throw StateError('remove() must be called after next()');
     }
     set.remove(lastReturned as T);
-    this._lastReturned = _noValue;
+    _lastReturned = _noValue;
   }
 }

--- a/lib/src/collection/impl/set_mutable.dart
+++ b/lib/src/collection/impl/set_mutable.dart
@@ -103,7 +103,7 @@ class DartMutableSet<T> extends Object implements KtMutableSet<T> {
 }
 
 class _MutableSetIterator<T> extends KtMutableIterator<T> {
-  _MutableSetIterator(KtMutableSet<T> set)
+  _MutableSetIterator(this.set)
       : _iterator = set.iter.iterator,
         lastReturned = null {
     _hasNext = _iterator.moveNext();
@@ -116,6 +116,7 @@ class _MutableSetIterator<T> extends KtMutableIterator<T> {
   T? nextValue;
   T? lastReturned;
   bool _hasNext = false;
+  final KtMutableSet<T> set;
 
   @override
   bool hasNext() => _hasNext;
@@ -134,11 +135,9 @@ class _MutableSetIterator<T> extends KtMutableIterator<T> {
 
   @override
   void remove() {
-    // removing from list is wrong because is is a copy of the original list.
-    // remove should modify the underlying list, not the copy
-    // see how kotlin solved this:
-    // https://github.com/JetBrains/kotlin/blob/ba6da7c40a6cc502508faf6e04fa105b96bc7777/libraries/stdlib/js/src/kotlin/collections/InternalHashCodeMap.kt
-    throw UnimplementedError(
-        "remove() in not yet implemented. Please vote for https://github.com/passsy/dart_kollection/issues/5 for prioritization");
+    final lastReturned = this.lastReturned;
+    if (lastReturned == null) throw StateError('remove() must be called after next()');
+    set.remove(lastReturned);
+    this.lastReturned = null;
   }
 }

--- a/lib/src/collection/kt_map_mutable.dart
+++ b/lib/src/collection/kt_map_mutable.dart
@@ -25,6 +25,8 @@ abstract class KtMutableMap<K, V> implements KtMap<K, V> {
   @override
   Map<K, V> asMap();
 
+  KtMutableIterator<KtMutableMapEntry<K, V>> iterator();
+
   // Modification Operations
   /// Associates the specified [value] with the specified [key] in the map.
   ///
@@ -95,9 +97,6 @@ extension KtMutableMapExtensions<K, V> on KtMutableMap<K, V> {
     put(key, answer);
     return answer;
   }
-
-  /// Returns an [Iterator] over the entries in the [Map].
-  KtMutableIterator<KtMutableMapEntry<K, V>> iterator() => entries.iterator();
 
   /// Puts all the given [pairs] into this [KtMutableMap] with the first component in the pair being the key and the second the value.
   void putAllPairs(KtIterable<KtPair<K, V>> pairs) {

--- a/test/collection/iterable_mutable_extensions_test.dart
+++ b/test/collection/iterable_mutable_extensions_test.dart
@@ -43,23 +43,23 @@ void main() {
 void testIterable(KtMutableIterable<T> Function<T>() emptyIterable,
     KtMutableIterable<T> Function<T>(Iterable<T> iterable) mutableIterableOf,
     {bool ordered = true}) {
-  group("removal functions throw", () {});
-
   group("removeAllWhere", () {
     test("removeAllWhere", () {
-      final list = mutableListOf("paul", "john", "max", "lisa");
-      list.removeAllWhere((it) => it.endsWith("x"));
+      final mutableIterable =
+          mutableIterableOf(["paul", "john", "max", "lisa"]);
+      mutableIterable.removeAllWhere((it) => it.endsWith("x"));
 
-      expect(list, listOf("paul", "john", "lisa"));
+      expect(mutableIterable.toSet(), setOf("paul", "john", "lisa"));
     });
   });
 
   group("retainAllWhere", () {
     test("retainAllWhere", () {
-      final list = mutableListOf("paul", "john", "max", "lisa");
-      list.retainAllWhere((it) => it.endsWith("x"));
+      final mutableIterable =
+          mutableIterableOf(["paul", "john", "max", "lisa"]);
+      mutableIterable.retainAllWhere((it) => it.endsWith("x"));
 
-      expect(list, listOf("max"));
+      expect(mutableIterable.toSet(), setOf("max"));
     });
   });
 }

--- a/test/collection/iterable_mutable_extensions_test.dart
+++ b/test/collection/iterable_mutable_extensions_test.dart
@@ -2,8 +2,6 @@ import "package:kt_dart/collection.dart";
 import "package:kt_dart/src/collection/impl/iterable.dart";
 import "package:test/test.dart";
 
-import "../test/assert_dart.dart";
-
 void main() {
   group("KtMutableIterableExtensions", () {
     group("mutableIterable", () {
@@ -49,23 +47,19 @@ void testIterable(KtMutableIterable<T> Function<T>() emptyIterable,
 
   group("removeAllWhere", () {
     test("removeAllWhere", () {
-      final iterable = mutableIterableOf(["paul", "john", "max", "lisa"]);
-      final e = catchException(
-          () => iterable.removeAllWhere((it) => it.endsWith("x")));
-      // TODO remove error assertion once implemented
-      expect(e, const TypeMatcher<UnimplementedError>());
-      //expect(iterable.toList(), listOf("paul", "john", "lisa"));
+      final list = mutableListOf("paul", "john", "max", "lisa");
+      list.removeAllWhere((it) => it.endsWith("x"));
+      
+      expect(list, listOf("paul", "john", "lisa"));
     });
   });
 
   group("retainAllWhere", () {
     test("retainAllWhere", () {
-      final iterable = mutableIterableOf(["paul", "john", "max", "lisa"]);
-      final e = catchException(
-          () => iterable.retainAllWhere((it) => it.endsWith("x")));
-      // TODO remove error assertion once implemented
-      expect(e, const TypeMatcher<UnimplementedError>());
-      //expect(iterable.toList(), listOf("max"));
+      final list = mutableListOf("paul", "john", "max", "lisa");
+      list.retainAllWhere((it) => it.endsWith("x"));
+      
+      expect(list, listOf("max"));
     });
   });
 }

--- a/test/collection/iterable_mutable_extensions_test.dart
+++ b/test/collection/iterable_mutable_extensions_test.dart
@@ -49,7 +49,7 @@ void testIterable(KtMutableIterable<T> Function<T>() emptyIterable,
     test("removeAllWhere", () {
       final list = mutableListOf("paul", "john", "max", "lisa");
       list.removeAllWhere((it) => it.endsWith("x"));
-      
+
       expect(list, listOf("paul", "john", "lisa"));
     });
   });
@@ -58,7 +58,7 @@ void testIterable(KtMutableIterable<T> Function<T>() emptyIterable,
     test("retainAllWhere", () {
       final list = mutableListOf("paul", "john", "max", "lisa");
       list.retainAllWhere((it) => it.endsWith("x"));
-      
+
       expect(list, listOf("max"));
     });
   });

--- a/test/collection/iterator_test.dart
+++ b/test/collection/iterator_test.dart
@@ -51,10 +51,37 @@ void main() {
       expect(e, const TypeMatcher<IndexOutOfBoundsException>());
     });
 
-    test("remove is not implemented", () {
-      final i = InterOpKtListIterator(["a", "b"], 0);
-      final e = catchException(() => i.remove());
-      expect(e, const TypeMatcher<UnimplementedError>());
+    test("remove() removes last returned element", () {
+      final list =  mutableListOf("a", "b", "c");
+      final iterator = list.iterator();
+      iterator.next();
+      iterator.remove();
+      expect(list, listOf("b", "c"));
+    });
+    
+    test("remove() can delete multiple elements", () {
+      final list =  mutableListOf("a", "b", "c");
+      final iterator = list.iterator();
+      iterator.next();
+      iterator.remove();
+      iterator.next();
+      iterator.next();
+      iterator.remove();
+      expect(list, listOf("b"));
+    });
+
+    test("remove() throws when there is no last returned element", () {
+      final iterator =  mutableListOf("a", "b", "c").iterator();
+      final exception = catchException(() => iterator.remove());
+      expect(exception, const TypeMatcher<IndexOutOfBoundsException>());
+    });
+
+    test("remove() throws when called multiple times in a row", () {
+      final iterator =  mutableListOf("a", "b", "c").iterator();
+      iterator.next();
+      iterator.remove();
+      final exception = catchException(() => iterator.remove());
+      expect(exception, const TypeMatcher<IndexOutOfBoundsException>());
     });
 
     test("add adds item to underlying list", () {

--- a/test/collection/iterator_test.dart
+++ b/test/collection/iterator_test.dart
@@ -52,15 +52,15 @@ void main() {
     });
 
     test("remove() removes last returned element", () {
-      final list =  mutableListOf("a", "b", "c");
+      final list = mutableListOf("a", "b", "c");
       final iterator = list.iterator();
       iterator.next();
       iterator.remove();
       expect(list, listOf("b", "c"));
     });
-    
+
     test("remove() can delete multiple elements", () {
-      final list =  mutableListOf("a", "b", "c");
+      final list = mutableListOf("a", "b", "c");
       final iterator = list.iterator();
       iterator.next();
       iterator.remove();
@@ -71,13 +71,13 @@ void main() {
     });
 
     test("remove() throws when there is no last returned element", () {
-      final iterator =  mutableListOf("a", "b", "c").iterator();
+      final iterator = mutableListOf("a", "b", "c").iterator();
       final exception = catchException(() => iterator.remove());
       expect(exception, const TypeMatcher<IndexOutOfBoundsException>());
     });
 
     test("remove() throws when called multiple times in a row", () {
-      final iterator =  mutableListOf("a", "b", "c").iterator();
+      final iterator = mutableListOf("a", "b", "c").iterator();
       iterator.next();
       iterator.remove();
       final exception = catchException(() => iterator.remove());

--- a/test/collection/list_mutable_extensions_test.dart
+++ b/test/collection/list_mutable_extensions_test.dart
@@ -312,4 +312,19 @@ void testList(
       expect(firstList, isNot(equals(secondList)));
     });
   });
+
+  test("remove item from list via iterator", () {
+    final pokemon = mutableListOf(
+      "Bulbasaur",
+      "Ivysaur",
+    );
+    final iterator = pokemon.iterator();
+    expect(iterator.hasNext(), isTrue);
+    final next = iterator.next();
+    expect(next, "Bulbasaur");
+
+    iterator.remove();
+    // removed first item
+    expect(pokemon, listOf("Ivysaur"));
+  });
 }

--- a/test/collection/list_mutable_extensions_test.dart
+++ b/test/collection/list_mutable_extensions_test.dart
@@ -327,4 +327,26 @@ void testList(
     // removed first item
     expect(pokemon, listOf("Ivysaur"));
   });
+
+  test("remove handles null value", () {
+    final pokemon = mutableListOf(
+      null,
+      "Bulbasaur",
+      "Ivysaur",
+    );
+    final KtMutableIterator<String?> i = pokemon.iterator();
+    expect(i.hasNext(), isTrue);
+    expect(i.next(), null);
+    i.remove(); // remove null
+
+    expect(i.hasNext(), isTrue);
+    expect(i.next(), "Bulbasaur");
+
+    expect(i.hasNext(), isTrue);
+    expect(i.next(), "Ivysaur");
+
+    expect(i.hasNext(), isFalse);
+
+    expect(pokemon, listOf("Bulbasaur", "Ivysaur"));
+  });
 }

--- a/test/collection/map_mutable_extensions_test.dart
+++ b/test/collection/map_mutable_extensions_test.dart
@@ -1,41 +1,32 @@
 import "package:kt_dart/collection.dart";
 import "package:test/test.dart";
 
-import "../test/assert_dart.dart";
-
 void main() {
   group("KtMutableMapExtensions", () {
     group("mutableMapFrom", () {
-      testMutableMap(<K, V>() => mutableMapFrom<K, V>(),
-          <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
+      testMutableMap(<K, V>() => mutableMapFrom<K, V>(), <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
     });
     group("KtMutableMap", () {
-      testMutableMap(<K, V>() => KtMutableMap<K, V>.empty(),
-          <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
+      testMutableMap(<K, V>() => KtMutableMap<K, V>.empty(), <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
     });
     group("hashMapFrom", () {
-      testMutableMap(<K, V>() => hashMapFrom<K, V>(),
-          <K, V>(Map<K, V> map) => hashMapFrom<K, V>(map),
-          ordered: false);
+      testMutableMap(<K, V>() => hashMapFrom<K, V>(), <K, V>(Map<K, V> map) => hashMapFrom<K, V>(map), ordered: false);
     });
     group("KtHashMap", () {
-      testMutableMap(<K, V>() => KtHashMap<K, V>.empty(),
-          <K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
+      testMutableMap(<K, V>() => KtHashMap<K, V>.empty(), <K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
           ordered: false);
     });
     group("linkedMapFrom", () {
-      testMutableMap(<K, V>() => linkedMapFrom<K, V>(),
-          <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
+      testMutableMap(<K, V>() => linkedMapFrom<K, V>(), <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
     });
     group("KtLinkedMap", () {
-      testMutableMap(<K, V>() => KtLinkedMap<K, V>.empty(),
-          <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
+      testMutableMap(<K, V>() => KtLinkedMap<K, V>.empty(), <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
     });
   });
 }
 
-void testMutableMap(KtMutableMap<K, V> Function<K, V>() emptyMap,
-    KtMutableMap<K, V> Function<K, V>(Map<K, V> map) mutableMapFrom,
+void testMutableMap(
+    KtMutableMap<K, V> Function<K, V>() emptyMap, KtMutableMap<K, V> Function<K, V>(Map<K, V> map) mutableMapFrom,
     {bool ordered = true}) {
   group("clear", () {
     test("clear items", () {
@@ -206,26 +197,6 @@ void testMutableMap(KtMutableMap<K, V> Function<K, V>() emptyMap,
       expect(next.value, "Ivysaur");
 
       expect(i.hasNext(), isFalse);
-    });
-
-    group("remove doesn't work", () {
-      test("iterator is iterates", () {
-        final pokemon = mutableMapFrom({
-          1: "Bulbasaur",
-          2: "Ivysaur",
-        });
-        final KtMutableIterator<KtMapEntry<int, String>> i = pokemon.iterator();
-        expect(i.hasNext(), isTrue);
-        final next = i.next();
-        expect(next.key, 1);
-        expect(next.value, "Bulbasaur");
-
-        // TODO replace error assertion with value assertion when https://github.com/passsy/dart_kollection/issues/5 has been fixed
-        final e = catchException(() => i.remove());
-        expect(e, equals(const TypeMatcher<UnimplementedError>()));
-        // removed first item
-        //expect(pokemon, mapFrom({2: "Ivysaur"}));
-      });
     });
   });
 

--- a/test/collection/map_mutable_extensions_test.dart
+++ b/test/collection/map_mutable_extensions_test.dart
@@ -205,15 +205,36 @@ void testMutableMap(
       1: "Bulbasaur",
       2: "Ivysaur",
     });
-    final KtMutableIterator<KtMapEntry<int, String>> i = pokemon.iterator();
-    expect(i.hasNext(), isTrue);
-    final next = i.next();
+    final iterator = pokemon.iterator();
+    expect(iterator.hasNext(), isTrue);
+    final next = iterator.next();
     expect(next.key, 1);
     expect(next.value, "Bulbasaur");
 
-    i.remove();
+    iterator.remove();
     // removed first item
     expect(pokemon, mapFrom({2: "Ivysaur"}));
+  });
+
+  test("iterator throws when remove() is called before next()", () {
+    final map = mutableMapFrom({
+      1: "Bulbasaur",
+      2: "Ivysaur",
+    });
+
+    expect(() => map.iterator().remove(), throwsStateError);
+  });
+
+  test("iterator throws when remove() is called multiple times in a row", () {
+    final map = mutableMapFrom({
+      1: "Bulbasaur",
+      2: "Ivysaur",
+    });
+    final iterator = map.iterator();
+    iterator.next();
+    iterator.remove();
+
+    expect(() => iterator.remove(), throwsStateError);
   });
 
   group("put", () {

--- a/test/collection/map_mutable_extensions_test.dart
+++ b/test/collection/map_mutable_extensions_test.dart
@@ -200,6 +200,24 @@ void testMutableMap(
     });
   });
 
+  group("remove doesn't work", () {
+    test("iterator is iterates", () {
+      final pokemon = mutableMapFrom({
+        1: "Bulbasaur",
+        2: "Ivysaur",
+      });
+      final KtMutableIterator<KtMapEntry<int, String>> i = pokemon.iterator();
+      expect(i.hasNext(), isTrue);
+      final next = i.next();
+      expect(next.key, 1);
+      expect(next.value, "Bulbasaur");
+
+      i.remove();
+      // removed first item
+      expect(pokemon, mapFrom({2: "Ivysaur"}));
+    });
+  });
+
   group("put", () {
     test("put", () {
       final pokemon = mutableMapFrom({

--- a/test/collection/map_mutable_extensions_test.dart
+++ b/test/collection/map_mutable_extensions_test.dart
@@ -200,22 +200,20 @@ void testMutableMap(
     });
   });
 
-  group("remove doesn't work", () {
-    test("iterator is iterates", () {
-      final pokemon = mutableMapFrom({
-        1: "Bulbasaur",
-        2: "Ivysaur",
-      });
-      final KtMutableIterator<KtMapEntry<int, String>> i = pokemon.iterator();
-      expect(i.hasNext(), isTrue);
-      final next = i.next();
-      expect(next.key, 1);
-      expect(next.value, "Bulbasaur");
-
-      i.remove();
-      // removed first item
-      expect(pokemon, mapFrom({2: "Ivysaur"}));
+  test("remove item from map via iterator", () {
+    final pokemon = mutableMapFrom({
+      1: "Bulbasaur",
+      2: "Ivysaur",
     });
+    final KtMutableIterator<KtMapEntry<int, String>> i = pokemon.iterator();
+    expect(i.hasNext(), isTrue);
+    final next = i.next();
+    expect(next.key, 1);
+    expect(next.value, "Bulbasaur");
+
+    i.remove();
+    // removed first item
+    expect(pokemon, mapFrom({2: "Ivysaur"}));
   });
 
   group("put", () {

--- a/test/collection/map_mutable_extensions_test.dart
+++ b/test/collection/map_mutable_extensions_test.dart
@@ -187,7 +187,7 @@ void testMutableMap(KtMutableMap<K, V> Function<K, V>() emptyMap,
   });
 
   group("iterator", () {
-    test("iterator is iterates", () {
+    test("iterator iterates", () {
       final pokemon = mutableMapFrom({
         1: "Bulbasaur",
         2: "Ivysaur",
@@ -205,43 +205,61 @@ void testMutableMap(KtMutableMap<K, V> Function<K, V>() emptyMap,
 
       expect(i.hasNext(), isFalse);
     });
-  });
 
-  test("remove item from map via iterator", () {
-    final pokemon = mutableMapFrom({
-      1: "Bulbasaur",
-      2: "Ivysaur",
-    });
-    final iterator = pokemon.iterator();
-    expect(iterator.hasNext(), isTrue);
-    final next = iterator.next();
-    expect(next.key, 1);
-    expect(next.value, "Bulbasaur");
-
-    iterator.remove();
-    // removed first item
-    expect(pokemon, mapFrom({2: "Ivysaur"}));
-  });
-
-  test("iterator throws when remove() is called before next()", () {
-    final map = mutableMapFrom({
-      1: "Bulbasaur",
-      2: "Ivysaur",
+    test("remove() handles null keys", () {
+      final pokemon = mutableMapFrom({
+        null: "Missingno",
+        1: "Bulbasaur",
+        2: "Ivysaur",
+      });
+      final KtMutableIterator<KtMapEntry<int?, String>> i = pokemon.iterator();
+      while (i.hasNext()) {
+        final next = i.next();
+        if (next.key == null) {
+          // remove Missingno
+          i.remove();
+          break;
+        }
+      }
+      expect(pokemon, mapFrom({1: "Bulbasaur", 2: "Ivysaur"}));
     });
 
-    expect(() => map.iterator().remove(), throwsStateError);
-  });
+    test("remove item from map via iterator", () {
+      final pokemon = mutableMapFrom({
+        1: "Bulbasaur",
+        2: "Ivysaur",
+      });
+      final iterator = pokemon.iterator();
+      expect(iterator.hasNext(), isTrue);
+      final next = iterator.next();
+      expect(next.key, 1);
+      expect(next.value, "Bulbasaur");
 
-  test("iterator throws when remove() is called multiple times in a row", () {
-    final map = mutableMapFrom({
-      1: "Bulbasaur",
-      2: "Ivysaur",
+      iterator.remove();
+      // removed first item
+      expect(pokemon, mapFrom({2: "Ivysaur"}));
     });
-    final iterator = map.iterator();
-    iterator.next();
-    iterator.remove();
 
-    expect(() => iterator.remove(), throwsStateError);
+    test("iterator throws when remove() is called before next()", () {
+      final map = mutableMapFrom({
+        1: "Bulbasaur",
+        2: "Ivysaur",
+      });
+
+      expect(() => map.iterator().remove(), throwsStateError);
+    });
+
+    test("iterator throws when remove() is called multiple times in a row", () {
+      final map = mutableMapFrom({
+        1: "Bulbasaur",
+        2: "Ivysaur",
+      });
+      final iterator = map.iterator();
+      iterator.next();
+      iterator.remove();
+
+      expect(() => iterator.remove(), throwsStateError);
+    });
   });
 
   group("put", () {

--- a/test/collection/map_mutable_extensions_test.dart
+++ b/test/collection/map_mutable_extensions_test.dart
@@ -4,29 +4,36 @@ import "package:test/test.dart";
 void main() {
   group("KtMutableMapExtensions", () {
     group("mutableMapFrom", () {
-      testMutableMap(<K, V>() => mutableMapFrom<K, V>(), <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
+      testMutableMap(<K, V>() => mutableMapFrom<K, V>(),
+          <K, V>(Map<K, V> map) => mutableMapFrom<K, V>(map));
     });
     group("KtMutableMap", () {
-      testMutableMap(<K, V>() => KtMutableMap<K, V>.empty(), <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
+      testMutableMap(<K, V>() => KtMutableMap<K, V>.empty(),
+          <K, V>(Map<K, V> map) => KtMutableMap<K, V>.from(map));
     });
     group("hashMapFrom", () {
-      testMutableMap(<K, V>() => hashMapFrom<K, V>(), <K, V>(Map<K, V> map) => hashMapFrom<K, V>(map), ordered: false);
+      testMutableMap(<K, V>() => hashMapFrom<K, V>(),
+          <K, V>(Map<K, V> map) => hashMapFrom<K, V>(map),
+          ordered: false);
     });
     group("KtHashMap", () {
-      testMutableMap(<K, V>() => KtHashMap<K, V>.empty(), <K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
+      testMutableMap(<K, V>() => KtHashMap<K, V>.empty(),
+          <K, V>(Map<K, V> map) => KtHashMap<K, V>.from(map),
           ordered: false);
     });
     group("linkedMapFrom", () {
-      testMutableMap(<K, V>() => linkedMapFrom<K, V>(), <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
+      testMutableMap(<K, V>() => linkedMapFrom<K, V>(),
+          <K, V>(Map<K, V> map) => linkedMapFrom<K, V>(map));
     });
     group("KtLinkedMap", () {
-      testMutableMap(<K, V>() => KtLinkedMap<K, V>.empty(), <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
+      testMutableMap(<K, V>() => KtLinkedMap<K, V>.empty(),
+          <K, V>(Map<K, V> map) => KtLinkedMap<K, V>.from(map));
     });
   });
 }
 
-void testMutableMap(
-    KtMutableMap<K, V> Function<K, V>() emptyMap, KtMutableMap<K, V> Function<K, V>(Map<K, V> map) mutableMapFrom,
+void testMutableMap(KtMutableMap<K, V> Function<K, V>() emptyMap,
+    KtMutableMap<K, V> Function<K, V>(Map<K, V> map) mutableMapFrom,
     {bool ordered = true}) {
   group("clear", () {
     test("clear items", () {

--- a/test/collection/set_mutable_extensions_test.dart
+++ b/test/collection/set_mutable_extensions_test.dart
@@ -63,4 +63,22 @@ void testSet(
       expect(pokemon, setOf("Bulbasaur"));
     }
   });
+
+  test("remove() handles null value", () {
+    final pokemon = mutableSetOf(
+      null,
+      "Bulbasaur",
+      "Ivysaur",
+    );
+    final KtMutableIterator<String?> i = pokemon.iterator();
+    while (i.hasNext()) {
+      final next = i.next();
+      if (next == null) {
+        // remove null
+        i.remove();
+        break;
+      }
+    }
+    expect(pokemon, setOf("Bulbasaur", "Ivysaur"));
+  });
 }

--- a/test/collection/set_mutable_extensions_test.dart
+++ b/test/collection/set_mutable_extensions_test.dart
@@ -45,4 +45,22 @@ void testSet(
       expect(dartList, {1});
     });
   });
+
+  test("remove item from ser via iterator", () {
+    final pokemon = mutableSetOf(
+      "Bulbasaur",
+      "Ivysaur",
+    );
+    final iterator = pokemon.iterator();
+    expect(iterator.hasNext(), isTrue);
+    final next = iterator.next();
+    iterator.remove();
+
+    // order is unknown, catch both cases
+    if (next == "Bulbasaur") {
+      expect(pokemon, setOf("Ivysaur"));
+    } else {
+      expect(pokemon, setOf("Bulbasaur"));
+    }
+  });
 }

--- a/test/collection/set_mutable_test.dart
+++ b/test/collection/set_mutable_test.dart
@@ -6,10 +6,12 @@ import "../test/assert_dart.dart";
 void main() {
   group("KtMutableSet", () {
     group("mutableSet", () {
-      testMutableSet(<T>() => KtMutableSet.empty(), mutableSetOf, mutableSetFrom);
+      testMutableSet(
+          <T>() => KtMutableSet.empty(), mutableSetOf, mutableSetFrom);
     });
     group("hashSet", () {
-      testMutableSet(<T>() => KtHashSet.empty(), hashSetOf, hashSetFrom, ordered: false);
+      testMutableSet(<T>() => KtHashSet.empty(), hashSetOf, hashSetFrom,
+          ordered: false);
     });
     group("linkedSet", () {
       testMutableSet(<T>() => KtLinkedSet.empty(), linkedSetOf, linkedSetFrom);
@@ -45,7 +47,17 @@ void main() {
 
 void testMutableSet(
     KtMutableSet<T> Function<T>() emptySet,
-    KtMutableSet<T> Function<T>([T arg0, T arg1, T arg2, T arg3, T arg4, T arg5, T arg6, T arg7, T arg8, T arg9])
+    KtMutableSet<T> Function<T>(
+            [T arg0,
+            T arg1,
+            T arg2,
+            T arg3,
+            T arg4,
+            T arg5,
+            T arg6,
+            T arg7,
+            T arg8,
+            T arg9])
         mutableSetOf,
     KtMutableSet<T> Function<T>(Iterable<T> iterable) mutableSetFrom,
     {bool ordered = true}) {
@@ -72,10 +84,10 @@ void testMutableSet(
     final set = mutableSetOf("a", "b", "c");
     final iterator = set.iterator();
     final e = catchException(() => iterator.remove());
-    
+
     expect(e, const TypeMatcher<StateError>());
   });
-  
+
   test("iterator().remove() throws when called multiple times in a row", () {
     final set = mutableSetOf("a", "b", "c");
     final iterator = set.iterator();
@@ -83,7 +95,7 @@ void testMutableSet(
     iterator.next();
     iterator.remove();
     final e = catchException(() => iterator.remove());
-    
+
     expect(e, const TypeMatcher<StateError>());
   });
 

--- a/test/collection/set_mutable_test.dart
+++ b/test/collection/set_mutable_test.dart
@@ -6,12 +6,10 @@ import "../test/assert_dart.dart";
 void main() {
   group("KtMutableSet", () {
     group("mutableSet", () {
-      testMutableSet(
-          <T>() => KtMutableSet.empty(), mutableSetOf, mutableSetFrom);
+      testMutableSet(<T>() => KtMutableSet.empty(), mutableSetOf, mutableSetFrom);
     });
     group("hashSet", () {
-      testMutableSet(<T>() => KtHashSet.empty(), hashSetOf, hashSetFrom,
-          ordered: false);
+      testMutableSet(<T>() => KtHashSet.empty(), hashSetOf, hashSetFrom, ordered: false);
     });
     group("linkedSet", () {
       testMutableSet(<T>() => KtLinkedSet.empty(), linkedSetOf, linkedSetFrom);
@@ -47,17 +45,7 @@ void main() {
 
 void testMutableSet(
     KtMutableSet<T> Function<T>() emptySet,
-    KtMutableSet<T> Function<T>(
-            [T arg0,
-            T arg1,
-            T arg2,
-            T arg3,
-            T arg4,
-            T arg5,
-            T arg6,
-            T arg7,
-            T arg8,
-            T arg9])
+    KtMutableSet<T> Function<T>([T arg0, T arg1, T arg2, T arg3, T arg4, T arg5, T arg6, T arg7, T arg8, T arg9])
         mutableSetOf,
     KtMutableSet<T> Function<T>(Iterable<T> iterable) mutableSetFrom,
     {bool ordered = true}) {
@@ -69,6 +57,34 @@ void testMutableSet(
   test("hashSetOf automatically removes duplicates", () {
     final set = hashSetOf("a", "b", "a", "c");
     expect(set.size, 3);
+  });
+
+  test("iterator().remove() removes last returned element", () {
+    final set = mutableSetOf("a", "b", "c");
+    final iterator = set.iterator();
+    final lastReturnedValue = iterator.next();
+    iterator.remove();
+
+    expect(set.contains(lastReturnedValue), false);
+  });
+
+  test("iterator().remove() throws when there is no last returned value", () {
+    final set = mutableSetOf("a", "b", "c");
+    final iterator = set.iterator();
+    final e = catchException(() => iterator.remove());
+    
+    expect(e, const TypeMatcher<StateError>());
+  });
+  
+  test("iterator().remove() throws when called multiple times in a row", () {
+    final set = mutableSetOf("a", "b", "c");
+    final iterator = set.iterator();
+    iterator.next();
+    iterator.next();
+    iterator.remove();
+    final e = catchException(() => iterator.remove());
+    
+    expect(e, const TypeMatcher<StateError>());
   });
 
   if (ordered) {


### PR DESCRIPTION
Looks like the comment message is no longer relevant, because _list appears to be the underlying list and not the copy (at least in most basic scenarios).

This implements removeAllWhere(), retailAllWhere() and fixes #5.

Please tell me if you need any changes in my implementation.